### PR TITLE
feat(attribute): Add `HasHref` trait and `href()` method to manage `href` attribute for HTML/SVG elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.4.1 Under development
 
+- Enh #14: Add `HasHref` trait and `href()` method to manage `href` attribute for HTML/SVG elements (@terabytesoftw)
+
 ## 0.4.0 December 27, 2025
 
 - Dep #13: Update `ui-awesome/html-helper` version constraint to `^0.6` in `composer.json` (@terabytesoftw)

--- a/src/Link/HasHref.php
+++ b/src/Link/HasHref.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Link;
+
+/**
+ * Trait for managing the HTML and SVG `href` attribute in tag rendering.
+ *
+ * Provides a standards-compliant, immutable API for setting the `href` attribute on HTML and SVG elements, following
+ * the HTML and SVG specifications for hyperlink and resource reference assignment.
+ *
+ * Intended for use in tags and components that require dynamic or programmatic manipulation of the `href` attribute,
+ * ensuring correct attribute handling and flexible link or resource control.
+ *
+ * Key features.
+ * - Designed for use in tags and components.
+ * - Enforces standards-compliant handling of the HTML and SVG `href` attribute.
+ * - Immutable method for setting or overriding the `href` attribute.
+ * - Supports string and `null` for flexible URL assignment.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#href
+ * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/href
+ * @property array $attributes HTML attributes array used by the implementing class.
+ * @phpstan-property mixed[] $attributes
+ * {@see \UIAwesome\Html\Core\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasHref
+{
+    /**
+     * Sets the HTML or SVG `href` attribute for the element.
+     *
+     * Creates a new instance with the specified URL or resource reference, supporting explicit assignment according to
+     * the HTML and SVG specifications for hyperlink and resource attributes.
+     *
+     * The `href` attribute defines the target URL or resource reference for the element. Accepts a string representing
+     * a valid URL, path, or fragment. Setting `href` to `null` unsets the attribute.
+     *
+     * @param string|null $value URL or resource reference to set for the element. Use a valid URL, path, or fragment as
+     * a string. Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `href` attribute.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#href
+     * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/href
+     *
+     * Usage example:
+     * ```php
+     * // sets the `href` attribute to an absolute URL
+     * $element->href('https://example.com/page');
+     *
+     * // sets the `href` attribute to a relative path
+     * $element->href('/about');
+     *
+     * // sets the `href` attribute to a fragment identifier
+     * $element->href('#section');
+     *
+     * // unsets the `href` attribute
+     * $element->href(null);
+     * ```
+     */
+    public function href(string|null $value): static
+    {
+        $new = clone $this;
+
+        if ($value === null) {
+            unset($new->attributes['href']);
+        } else {
+            $new->attributes['href'] = $value;
+        }
+
+        return $new;
+    }
+}

--- a/tests/Link/HasHrefTest.php
+++ b/tests/Link/HasHrefTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Link;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Link\HasHref;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\Link\HrefProvider;
+use UIAwesome\Html\Attribute\Tests\Support\Stub\HasAttributes;
+use UIAwesome\Html\Helper\Attributes;
+
+/**
+ * Test suite for {@see HasHref} trait functionality and behavior.
+ *
+ * Validates the management of the HTML and SVG `href` attribute according to the HTML and SVG specifications.
+ *
+ * Ensures correct handling, immutability, and validation of the `href` attribute in tag rendering, supporting string
+ * and `null` for dynamic assignment.
+ *
+ * Test coverage:
+ * - Accurate rendering of attributes with the `href` attribute.
+ * - Data provider-driven validation for edge cases and expected behaviors.
+ * - Immutability of the trait's API when setting or overriding the `href` attribute.
+ * - Proper assignment, overriding, and validation of `href` value.
+ *
+ * {@see HrefProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('link')]
+final class HasHrefTest extends TestCase
+{
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(HrefProvider::class, 'renderAttribute')]
+    public function testRenderAttributesWithHrefAttribute(
+        string|null $href,
+        array $attributes,
+        string $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasHref;
+        };
+
+        $instance = $instance->attributes($attributes)->href($href);
+
+        self::assertSame(
+            $expected,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testReturnEmptyWhenHrefAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasHref;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingHrefAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasHref;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->href('https://example.com'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(HrefProvider::class, 'values')]
+    public function testSetHrefAttributeValue(
+        string|null $href,
+        array $attributes,
+        string $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasHref;
+        };
+
+        $instance = $instance->attributes($attributes)->href($href);
+
+        self::assertSame(
+            $expected,
+            $instance->getAttributes()['href'] ?? '',
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/Link/HrefProvider.php
+++ b/tests/Support/Provider/Link/HrefProvider.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider\Link;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Link\HasHrefTest} class.
+ *
+ * Supplies comprehensive test data for validating the handling of the HTML and SVG `href` attribute in tag rendering,
+ * ensuring standards-compliant assignment, override behavior, and value propagation according to the HTML and SVG
+ * specifications.
+ *
+ * The test data covers real-world scenarios for setting, overriding, and removing the `href` attribute, supporting
+ * string and `null`, to maintain consistent output across different rendering configurations.
+ *
+ * The provider organizes test cases with descriptive names for clear identification of failure cases during test
+ * execution and debugging sessions.
+ *
+ * Key features.
+ * - Ensures correct propagation, assignment, override, and removal of the `href` attribute in HTML/SVG element
+ *   rendering.
+ * - Named test data sets for precise failure identification.
+ * - Validation of string and `null` for the `href` attribute, including replacement and unset scenarios.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class HrefProvider
+{
+    /**
+     * Provides test cases for rendered HTML/SVG `href` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the `href` attribute, including string and
+     * `null`, as well as replacement scenarios.
+     *
+     * Each test case includes the input value, the initial attributes, the expected rendered output, and an assertion
+     * message for clear identification.
+     *
+     * @return array Test data for rendered `href` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{string|null, mixed[], string, string}>
+     */
+    public static function renderAttribute(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'https://example.com/new',
+                ['href' => 'https://example.com/old'],
+                ' href="https://example.com/new"',
+                "Should return new 'href' after replacing the existing 'href' attribute.",
+            ],
+            'string' => [
+                'https://example.com/page',
+                [],
+                ' href="https://example.com/page"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string fragment identifier' => [
+                '#section',
+                [],
+                ' href="#section"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string relative path' => [
+                '/about',
+                [],
+                ' href="/about"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['href' => 'https://example.com/old'],
+                '',
+                "Should unset the 'href' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+
+    /**
+     * Provides test cases for HTML/SVG `href` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the `href` attribute, including string and
+     * `null`, as well as replacement scenarios.
+     *
+     * Each test case includes the input value, the initial attributes, the expected value, and an assertion message for
+     * clear identification.
+     *
+     * @return array Test data for `href` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{string|null, mixed[], string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'https://example.com/new',
+                ['href' => 'https://example.com/old'],
+                'https://example.com/new',
+                "Should return new 'href' after replacing the existing 'href' attribute.",
+            ],
+            'string' => [
+                'https://example.com/page',
+                [],
+                'https://example.com/page',
+                'Should return the attribute value after setting it.',
+            ],
+            'string fragment identifier' => [
+                '#section',
+                [],
+                '#section',
+                'Should return a fragment identifier as the href attribute value.',
+            ],
+            'string relative path' => [
+                '/about',
+                [],
+                '/about',
+                'Should return a relative path as the href attribute value.',
+            ],
+            'unset with null' => [
+                null,
+                ['href' => 'https://example.com/old'],
+                '',
+                "Should unset the 'href' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a trait for managing href attributes on HTML and SVG elements with an immutable API.

* **Tests**
  * Added comprehensive test suite to validate href attribute behavior including rendering, immutability, and value assignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->