### PR TITLE
feat(attribute): Add `HasCrossorigin` trait and `crossorigin()` method to manage `crossorigin` attribute for HTML/SVG elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # ChangeLog
 
-## 0.4.1 Under development
+## 0.5.0 Under development
 
 - Enh #14: Add `HasHref` trait and `href()` method to manage `href` attribute for HTML/SVG elements (@terabytesoftw)
+- Enh #15: Add `HasCrossorigin` trait and `crossorigin()` method to manage `crossorigin` attribute for HTML/SVG elements (@terabytesoftw)
 
 ## 0.4.0 December 27, 2025
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.5.x-dev"
+            "dev-main": "0.6.x-dev"
         }
     },
     "config": {

--- a/src/Media/HasCrossorigin.php
+++ b/src/Media/HasCrossorigin.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Media;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\Crossorigin;
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `crossorigin` attribute in tag rendering.
+ *
+ * Provides a standards-compliant, immutable API for setting the `crossorigin` attribute on HTML elements, following the
+ * HTML specification for CORS (Cross-Origin Resource Sharing) settings.
+ *
+ * Intended for use in tags and components that require dynamic or programmatic manipulation of the CORS attribute,
+ * ensuring correct attribute handling, type safety, and value validation.
+ *
+ * Key features.
+ * - Designed for use in media elements (img, video, audio), script, link, and SVG elements.
+ * - Enforces standards-compliant handling of the HTML `crossorigin` attribute.
+ * - Immutable method for setting or overriding the `crossorigin` attribute.
+ * - Supports string, UnitEnum, and `null` for flexible CORS assignment.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin
+ * @property array $attributes HTML attributes array used by the implementing class.
+ * @phpstan-property mixed[] $attributes
+ * {@see \UIAwesome\Html\Core\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasCrossorigin
+{
+    /**
+     * Sets the HTML `crossorigin` attribute for the element.
+     *
+     * Creates a new instance with the specified CORS setting value, supporting explicit assignment according to the
+     * HTML specification for crossorigin attributes.
+     *
+     * @param string|UnitEnum|null $value CORS setting value to set for the element. Use a valid CORS token (for
+     * example, `anonymous`, `use-credentials`). Can be `null` to unset the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `crossorigin` attribute.
+     *
+     * @link https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
+     *
+     * Usage example:
+     * ```php
+     * // sets the `crossorigin` attribute to `anonymous`
+     * $element->crossorigin('anonymous');
+     *
+     * // sets the `crossorigin` attribute using enum
+     * $element->crossorigin(Crossorigin::ANONYMOUS);
+     *
+     * // unsets the `crossorigin` attribute
+     * $element->crossorigin(null);
+     * ```
+     */
+    public function crossorigin(string|UnitEnum|null $value): static
+    {
+        $new = clone $this;
+
+        if ($value === null) {
+            unset($new->attributes['crossorigin']);
+        } else {
+            Validator::oneOf($value, Crossorigin::cases(), 'crossorigin');
+
+            $new->attributes['crossorigin'] = $value;
+        }
+
+        return $new;
+    }
+}

--- a/src/Values/Crossorigin.php
+++ b/src/Values/Crossorigin.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents standardized crossorigin values for HTML and SVG elements.
+ *
+ * Provides a type-safe set of CORS (Cross-Origin Resource Sharing) policy tokens and concise documentation aligned with
+ * the MDN reference and the CORS specification.
+ *
+ * Key features.
+ * - Designed for use in media elements (img, video, audio), script, link, and SVG elements.
+ * - Suitable for rendering HTML attributes in view helpers and components.
+ * - Values follow the CORS tokens listed in the MDN documentation.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Crossorigin: string
+{
+    /**
+     * `anonymous` - CORS requests for this element will have the credentials flag set to 'same-origin'.
+     *
+     * This is the default value when the attribute is present without a value. When not specified, the resource is
+     * fetched without a CORS request (i.e., without sending the Origin HTTP header).
+     *
+     * @link https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
+     */
+    case ANONYMOUS = 'anonymous';
+
+    /**
+     * `use-credentials` - CORS requests for this element will have the credentials flag set to 'include'.
+     *
+     * This value will include credentials (cookies, authorization headers, or TLS client certificates) in CORS
+     * requests.
+     *
+     * @link https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
+     */
+    case USE_CREDENTIALS = 'use-credentials';
+}

--- a/tests/Media/HasCrossoriginTest.php
+++ b/tests/Media/HasCrossoriginTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Media;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Media\HasCrossorigin;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\Media\CrossoriginProvider;
+use UIAwesome\Html\Attribute\Tests\Support\Stub\HasAttributes;
+use UIAwesome\Html\Attribute\Values\Crossorigin;
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UnitEnum;
+
+/**
+ * Test suite for {@see HasCrossorigin} trait functionality and behavior.
+ *
+ * Validates the management of the HTML `crossorigin` attribute according to the HTML Living Standard specification.
+ *
+ * Ensures correct handling, immutability, and validation of the `crossorigin` attribute in tag rendering, supporting
+ * string and UnitEnum for dynamic assignment.
+ *
+ * Test coverage:
+ * - Accurate rendering of attributes with the `crossorigin` attribute.
+ * - Data provider-driven validation for edge cases and expected behaviors.
+ * - Error handling for invalid attributes.
+ * - Immutability of the trait's API when setting or overriding the `crossorigin` attribute.
+ * - Proper assignment, overriding, and validation of `crossorigin` value.
+ *
+ * {@see CrossoriginProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('media')]
+final class HasCrossoriginTest extends TestCase
+{
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(CrossoriginProvider::class, 'renderAttribute')]
+    public function testRenderAttributesWithCrossoriginAttribute(
+        string|UnitEnum|null $crossorigin,
+        array $attributes,
+        string|UnitEnum $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasCrossorigin;
+        };
+
+        $instance = $instance->attributes($attributes)->crossorigin($crossorigin);
+
+        self::assertSame(
+            $expected,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testReturnEmptyWhenCrossoriginAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasCrossorigin;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingCrossoriginAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasCrossorigin;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->crossorigin(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(CrossoriginProvider::class, 'values')]
+    public function testSetCrossoriginAttributeValue(
+        string|UnitEnum|null $crossorigin,
+        array $attributes,
+        string|UnitEnum $expected,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasCrossorigin;
+        };
+
+        $instance = $instance->attributes($attributes)->crossorigin($crossorigin);
+
+        self::assertSame(
+            $expected,
+            $instance->getAttributes()['crossorigin'] ?? '',
+            $message,
+        );
+    }
+
+    public function testThrowExceptionWhenSettingInvalidCrossoriginValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasCrossorigin;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                'crossorigin',
+                implode('\', \'', Enum::normalizeArray(Crossorigin::cases())),
+            ),
+        );
+
+        $instance->crossorigin('invalid-value');
+    }
+}

--- a/tests/Support/Provider/Media/CrossoriginProvider.php
+++ b/tests/Support/Provider/Media/CrossoriginProvider.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider\Media;
+
+use UIAwesome\Html\Attribute\Tests\Support\EnumDataGenerator;
+use UIAwesome\Html\Attribute\Values\Crossorigin;
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Media\HasCrossoriginTest} class.
+ *
+ * Supplies comprehensive test data for validating the handling of the HTML `crossorigin` attribute in tag rendering,
+ * ensuring standards-compliant assignment, override behavior, and value propagation according to the HTML
+ * specification.
+ *
+ * The test data covers real-world scenarios for setting, overriding, and removing the `crossorigin` attribute,
+ * supporting string, UnitEnum, and `null`, to maintain consistent output across different rendering configurations.
+ *
+ * The provider organizes test cases with descriptive names for clear identification of failure cases during test
+ * execution and debugging sessions.
+ *
+ * Key features.
+ * - Ensures correct propagation, assignment, override, and removal of the `crossorigin` attribute in HTML element
+ *   rendering.
+ * - Named test data sets for precise failure identification.
+ * - Validation of string, UnitEnum, and `null` for the `crossorigin` attribute, including replacement and unset
+ *   scenarios.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class CrossoriginProvider
+{
+    /**
+     * Provides test cases for rendered HTML `crossorigin` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the HTML `crossorigin` attribute,
+     * including string, UnitEnum, and `null`, as well as replacement scenarios.
+     *
+     * Each test case includes the input value, the initial attributes, the expected rendered output, and an assertion
+     * message for clear identification.
+     *
+     * @return array Test data for rendered `crossorigin` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string}>
+     */
+    public static function renderAttribute(): array
+    {
+        $enumCases = EnumDataGenerator::cases(Crossorigin::class, 'crossorigin', true);
+
+        $staticCase = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'enum replace existing' => [
+                Crossorigin::ANONYMOUS,
+                ['crossorigin' => 'use-credentials'],
+                ' crossorigin="anonymous"',
+                "Should return new 'crossorigin' after replacing the existing 'crossorigin' attribute with " .
+                'enum value.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'anonymous',
+                ['crossorigin' => 'use-credentials'],
+                ' crossorigin="anonymous"',
+                "Should return new 'crossorigin' after replacing the existing 'crossorigin' attribute.",
+            ],
+            'string' => [
+                'anonymous',
+                [],
+                ' crossorigin="anonymous"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['crossorigin' => 'anonymous'],
+                '',
+                "Should unset the 'crossorigin' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+
+    /**
+     * Provides test cases for HTML `crossorigin` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the HTML `crossorigin` attribute,
+     * including string, UnitEnum, and `null`, as well as replacement scenarios.
+     *
+     * Each test case includes the input value, the initial attributes, the expected value, and an assertion message for
+     * clear identification.
+     *
+     * @return array Test data for `crossorigin` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataGenerator::cases(Crossorigin::class, 'crossorigin', false);
+
+        $staticCase = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'anonymous',
+                ['crossorigin' => 'use-credentials'],
+                'anonymous',
+                "Should return new 'crossorigin' after replacing the existing 'crossorigin' attribute.",
+            ],
+            'string' => [
+                'anonymous',
+                [],
+                'anonymous',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['crossorigin' => 'anonymous'],
+                '',
+                "Should unset the 'crossorigin' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added crossorigin attribute support for HTML and SVG elements with type-safe CORS policy values (anonymous, use-credentials).

* **Version**
  * Bumped version from 0.4.1 to 0.5.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->