### PR TITLE
feat(attribute): Add `HasDecoding` trait and `decoding()` method to manage `decoding` attribute for HTML/SVG elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enh #17: Add development guide and sync metadata instructions and update testing documentation (@terabytesoftw)
 - Enh #18: Move attribute traits from `ui-awesome/html-core` package and update related imports accordingly (@terabytesoftw)
 - Bug #19: Update alert content in SVGs to reflect accurate descriptions for MDN standards compliance and specific & lightweight features (@terabytesoftw)
+- Enh #20: Add `HasDecoding` trait and `decoding()` method to manage `decoding` attribute for HTML/SVG elements (@terabytesoftw)
 
 ## 0.4.0 December 27, 2025
 

--- a/src/Element/HasDecoding.php
+++ b/src/Element/HasDecoding.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Element;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\{Decoding, ElementAttribute};
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML/SVG `decoding` attribute in tag rendering.
+ *
+ * Provides a standards-compliant, immutable API for setting the `decoding` attribute on HTML and SVG image elements,
+ * following the HTML specification for image decoding hints.
+ *
+ * Intended for use in image elements that require dynamic or programmatic manipulation of the decoding behavior,
+ * ensuring correct attribute handling, type safety, and value validation.
+ *
+ * Key features.
+ * - Designed for use in image elements (img, SVG image) requiring decoding hint assignment.
+ * - Enforces standards-compliant handling of the HTML/SVG `decoding` attribute.
+ * - Immutable method for setting or overriding the `decoding` attribute.
+ * - Supports string, UnitEnum, and `null` for flexible decoding hint assignment.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#decoding
+ * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/decoding
+ * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasDecoding
+{
+    /**
+     * Sets the HTML/SVG `decoding` attribute for the element.
+     *
+     * Creates a new instance with the specified decoding hint value, supporting explicit assignment according to the
+     * HTML specification for decoding attributes.
+     *
+     * @param string|UnitEnum|null $value Decoding hint value to set for the element. Use a valid decoding token (for
+     * example, `async`, `sync`, `auto`). Can be `null` to unset the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `decoding` attribute.
+     *
+     * @link https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decoding
+     *
+     * Usage example:
+     * ```php
+     * // sets the `decoding` attribute to `async`
+     * $element->decoding('async');
+     *
+     * // sets the `decoding` attribute using enum
+     * $element->decoding(Decoding::ASYNC);
+     *
+     * // unsets the `decoding` attribute
+     * $element->decoding(null);
+     * ```
+     */
+    public function decoding(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, Decoding::cases(), ElementAttribute::DECODING);
+
+        return $this->addAttribute(ElementAttribute::DECODING, $value);
+    }
+}

--- a/src/Values/Decoding.php
+++ b/src/Values/Decoding.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents standardized values for the HTML/SVG `decoding` attribute.
+ *
+ * Provides a type-safe, standards-compliant set of decoding hint identifiers for use in element rendering, attributes,
+ * and view helpers, ensuring technical consistency with the HTML specification and modern web standards.
+ *
+ * Key features.
+ * - Designed for use in image elements (img, SVG image) requiring decoding hint assignment.
+ * - Integration-ready for tag rendering and element generation APIs.
+ * - Strict mapping of decoding values for semantic markup generation and performance optimization.
+ * - Values follow the HTML specification for decoding: `async`, `sync`, and `auto`.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/decoding
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Decoding: string
+{
+    /**
+     * Decode the image asynchronously, after rendering and presenting the other content (`async`).
+     *
+     * The browser will render and present other content first, then decode the image and present it later.
+     */
+    case ASYNC = 'async';
+
+    /**
+     * No preference for the decoding mode (`auto`).
+     *
+     * The browser decides what is best for the user. This is the default value.
+     */
+    case AUTO = 'auto';
+
+    /**
+     * Decode the image synchronously along with rendering the other content (`sync`).
+     *
+     * The browser will decode the image along with rendering other content and present everything together.
+     */
+    case SYNC = 'sync';
+}

--- a/src/Values/ElementAttribute.php
+++ b/src/Values/ElementAttribute.php
@@ -14,6 +14,13 @@ enum ElementAttribute: string
     case ALT = 'alt';
 
     /**
+     * `decoding` — Provides a hint to the browser for image decoding behavior.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/decoding
+     */
+    case DECODING = 'decoding';
+
+    /**
      * `height` — Specifies the height of certain elements.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#height

--- a/tests/Element/HasDecodingTest.php
+++ b/tests/Element/HasDecodingTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Element;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Element\HasDecoding;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\Element\DecodingProvider;
+use UIAwesome\Html\Attribute\Values\{Decoding, ElementAttribute};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Test suite for {@see HasDecoding} trait functionality and behavior.
+ *
+ * Validates the management of the HTML/SVG `decoding` attribute according to the HTML Living Standard specification.
+ *
+ * Ensures correct handling, immutability, and validation of the `decoding` attribute in tag rendering, supporting
+ * string, UnitEnum, and `null` for dynamic assignment.
+ *
+ * Test coverage:
+ * - Accurate rendering of attributes with the `decoding` attribute.
+ * - Data provider-driven validation for edge cases and expected behaviors.
+ * - Error handling for invalid attributes.
+ * - Immutability of the trait's API when setting or overriding the `decoding` attribute.
+ * - Proper assignment, overriding, and validation of `decoding` value.
+ *
+ * {@see DecodingProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasDecodingTest extends TestCase
+{
+    public function testReturnEmptyWhenDecodingAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasDecoding;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingDecodingAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasDecoding;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->decoding(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(DecodingProvider::class, 'values')]
+    public function testSetDecodingAttributeValue(
+        string|UnitEnum|null $decoding,
+        array $attributes,
+        string|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasDecoding;
+        };
+
+        $instance = $instance->attributes($attributes)->decoding($decoding);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttributes()[ElementAttribute::DECODING->value] ?? '',
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testThrowExceptionWhenSettingInvalidDecodingValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasDecoding;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                ElementAttribute::DECODING->value,
+                implode('\', \'', Enum::normalizeArray(Decoding::cases())),
+            ),
+        );
+
+        $instance->decoding('invalid-value');
+    }
+}

--- a/tests/Support/Provider/Element/DecodingProvider.php
+++ b/tests/Support/Provider/Element/DecodingProvider.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider\Element;
+
+use UIAwesome\Html\Attribute\Tests\Support\EnumDataGenerator;
+use UIAwesome\Html\Attribute\Values\{Decoding, ElementAttribute};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Element\HasDecodingTest} class.
+ *
+ * Supplies comprehensive test data for validating the handling of the HTML/SVG `decoding` attribute in tag rendering,
+ * ensuring standards-compliant assignment, override behavior, and value propagation according to the HTML
+ * specification.
+ *
+ * The test data covers real-world scenarios for setting, overriding, and removing the `decoding` attribute,
+ * supporting string, UnitEnum, and `null`, to maintain consistent output across different rendering configurations.
+ *
+ * The provider organizes test cases with descriptive names for clear identification of failure cases during test
+ * execution and debugging sessions.
+ *
+ * Key features.
+ * - Ensures correct propagation, assignment, override, and removal of the `decoding` attribute in HTML element
+ *   rendering.
+ * - Named test data sets for precise failure identification.
+ * - Validation of string, UnitEnum, and `null` for the `decoding` attribute, including replacement and unset
+ *   scenarios.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class DecodingProvider
+{
+    /**
+     * Provides test cases for HTML/SVG `decoding` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the HTML/SVG `decoding` attribute,
+     * including string, UnitEnum, and `null`, as well as replacement scenarios.
+     *
+     * Each test case includes the input value, the initial attributes, the expected value, and an assertion message for
+     * clear identification.
+     *
+     * @return array Test data for `decoding` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataGenerator::cases(Decoding::class, ElementAttribute::DECODING);
+
+        $staticCase = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'async',
+                ['decoding' => 'sync'],
+                'async',
+                ' decoding="async"',
+                "Should return new 'decoding' after replacing the existing 'decoding' attribute.",
+            ],
+            'string' => [
+                'async',
+                [],
+                'async',
+                ' decoding="async"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['decoding' => 'async'],
+                '',
+                '',
+                "Should unset the 'decoding' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the HTML/SVG decoding attribute, enabling developers to specify image element rendering behavior with three standardized options: async, auto, and sync. The implementation includes an immutable API design with standard-compliant validation to ensure proper attribute handling and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->