### PR TITLE
feat(attribute): Add `HasFetchpriority` trait and `fetchpriority()` method to manage `fetchpriority` attribute for HTML/SVG elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enh #18: Move attribute traits from `ui-awesome/html-core` package and update related imports accordingly (@terabytesoftw)
 - Bug #19: Update alert content in SVGs to reflect accurate descriptions for MDN standards compliance and specific & lightweight features (@terabytesoftw)
 - Enh #20: Add `HasDecoding` trait and `decoding()` method to manage `decoding` attribute for HTML/SVG elements (@terabytesoftw)
+- Ebh #21: Add `HasFetchpriority` trait and `fetchpriority()` method to manage `fetchpriority` attribute for HTML/SVG elements (@terabytesoftw)
 
 ## 0.4.0 December 27, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Enh #18: Move attribute traits from `ui-awesome/html-core` package and update related imports accordingly (@terabytesoftw)
 - Bug #19: Update alert content in SVGs to reflect accurate descriptions for MDN standards compliance and specific & lightweight features (@terabytesoftw)
 - Enh #20: Add `HasDecoding` trait and `decoding()` method to manage `decoding` attribute for HTML/SVG elements (@terabytesoftw)
-- Ebh #21: Add `HasFetchpriority` trait and `fetchpriority()` method to manage `fetchpriority` attribute for HTML/SVG elements (@terabytesoftw)
+- Enh #21: Add `HasFetchpriority` trait and `fetchpriority()` method to manage `fetchpriority` attribute for HTML/SVG elements (@terabytesoftw)
 
 ## 0.4.0 December 27, 2025
 

--- a/src/HasFetchpriority.php
+++ b/src/HasFetchpriority.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\{Attribute, Fetchpriority};
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `fetchpriority` attribute in tag rendering.
+ *
+ * Provides a standards-compliant, immutable API for setting the `fetchpriority` attribute on HTML elements, following
+ * the HTML specification for resource fetch prioritization.
+ *
+ * Intended for use in tags and components that require dynamic or programmatic manipulation of the fetch priority
+ * attribute, ensuring correct attribute handling, type safety, and value validation.
+ *
+ * Key features.
+ * - Designed for use in img, link, svg, and script elements.
+ * - Enforces standards-compliant handling of the HTML `fetchpriority` attribute.
+ * - Immutable method for setting or overriding the `fetchpriority` attribute.
+ * - Supports string, UnitEnum, and `null` for flexible priority assignment.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/fetchpriority
+ * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasFetchpriority
+{
+    /**
+     * Sets the HTML `fetchpriority` attribute for the element.
+     *
+     * Creates a new instance with the specified fetch priority value, supporting explicit assignment according to the
+     * HTML specification for fetchpriority attributes.
+     *
+     * @param string|UnitEnum|null $value Fetch priority value to set for the element. Use a valid priority hint (for
+     * example, `high`, `low`, `auto`). Can be `null` to unset the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `fetchpriority` attribute.
+     *
+     * @link https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes
+     *
+     * Usage example:
+     * ```php
+     * // sets the `fetchpriority` attribute to `high`
+     * $element->fetchpriority('high');
+     *
+     * // sets the `fetchpriority` attribute using enum
+     * $element->fetchpriority(Fetchpriority::HIGH);
+     *
+     * // unsets the `fetchpriority` attribute
+     * $element->fetchpriority(null);
+     * ```
+     */
+    public function fetchpriority(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, Fetchpriority::cases(), Attribute::FETCHPRIORITY);
+
+        return $this->addAttribute(Attribute::FETCHPRIORITY, $value);
+    }
+}

--- a/src/Values/Fetchpriority.php
+++ b/src/Values/Fetchpriority.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents standardized values for the HTML/SVG `fetchpriority` attribute.
+ *
+ * Provides a type-safe set of fetch priority hints for resource loading optimization, aligned with the MDN reference
+ * and the HTML specification for resource prioritization.
+ *
+ * Key features.
+ * - Designed for use in img, link, and script elements.
+ * - Suitable for rendering HTML attributes in view helpers and components.
+ * - Values follow the enumerated attribute tokens listed in the MDN documentation.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/fetchpriority
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Fetchpriority: string
+{
+    /**
+     * `auto` - Does not set a preference for the fetch priority.
+     *
+     * This is the default value when the attribute is not specified or when an invalid value is set. The browser
+     * determines the priority based on its own heuristics.
+     *
+     * @link https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes
+     */
+    case AUTO = 'auto';
+    /**
+     * `high` - Fetches the external resource at a high priority relative to other external resources.
+     *
+     * This value should be used sparingly for resources that significantly contribute to user experience metrics
+     * such as the Largest Contentful Paint (LCP).
+     *
+     * @link https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes
+     */
+    case HIGH = 'high';
+
+    /**
+     * `low` - Fetches the external resource at a low priority relative to other external resources.
+     *
+     * This value is useful for resources that are not immediately necessary for the initial page load and can
+     * be deferred.
+     *
+     * @link https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes
+     */
+    case LOW = 'low';
+}

--- a/tests/HasFetchpriorityTest.php
+++ b/tests/HasFetchpriorityTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasFetchpriority;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\FetchpriorityProvider;
+use UIAwesome\Html\Attribute\Values\{Attribute, Fetchpriority};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Test suite for {@see HasFetchpriority} trait functionality and behavior.
+ *
+ * Validates the management of the HTML `fetchpriority` attribute according to the HTML Living Standard specification.
+ *
+ * Ensures correct handling, immutability, and validation of the `fetchpriority` attribute in tag rendering, supporting
+ * string and UnitEnum for dynamic assignment.
+ *
+ * Test coverage:
+ * - Accurate rendering of attributes with the `fetchpriority` attribute.
+ * - Data provider-driven validation for edge cases and expected behaviors.
+ * - Error handling for invalid attributes.
+ * - Immutability of the trait's API when setting or overriding the `fetchpriority` attribute.
+ * - Proper assignment, overriding, and validation of `fetchpriority` value.
+ *
+ * {@see FetchpriorityProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasFetchpriorityTest extends TestCase
+{
+    public function testReturnEmptyWhenFetchpriorityAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasFetchpriority;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingFetchpriorityAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasFetchpriority;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->fetchpriority(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(FetchpriorityProvider::class, 'values')]
+    public function testSetFetchpriorityAttributeValue(
+        string|UnitEnum|null $fetchpriority,
+        array $attributes,
+        string|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasFetchpriority;
+        };
+
+        $instance = $instance->attributes($attributes)->fetchpriority($fetchpriority);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttributes()[Attribute::FETCHPRIORITY->value] ?? '',
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testThrowExceptionWhenSettingInvalidFetchpriorityValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasFetchpriority;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                Attribute::FETCHPRIORITY->value,
+                implode('\', \'', Enum::normalizeArray(Fetchpriority::cases())),
+            ),
+        );
+
+        $instance->fetchpriority('invalid-value');
+    }
+}

--- a/tests/Support/Provider/FetchpriorityProvider.php
+++ b/tests/Support/Provider/FetchpriorityProvider.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use UIAwesome\Html\Attribute\Tests\Support\EnumDataGenerator;
+use UIAwesome\Html\Attribute\Values\{Attribute, Fetchpriority};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasFetchpriorityTest} class.
+ *
+ * Supplies comprehensive test data for validating the handling of the HTML `fetchpriority` attribute in tag rendering,
+ * ensuring standards-compliant assignment, override behavior, and value propagation according to the HTML
+ * specification.
+ *
+ * The test data covers real-world scenarios for setting, overriding, and removing the `fetchpriority` attribute,
+ * supporting string, UnitEnum, and `null`, to maintain consistent output across different rendering configurations.
+ *
+ * The provider organizes test cases with descriptive names for clear identification of failure cases during test
+ * execution and debugging sessions.
+ *
+ * Key features.
+ * - Ensures correct propagation, assignment, override, and removal of the `fetchpriority` attribute in HTML element
+ *   rendering.
+ * - Named test data sets for precise failure identification.
+ * - Validation of string, UnitEnum, and `null` for the `fetchpriority` attribute, including replacement and unset
+ *   scenarios.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class FetchpriorityProvider
+{
+    /**
+     * Provides test cases for HTML `fetchpriority` attribute scenarios.
+     *
+     * Supplies test data for validating assignment, override, and removal of the HTML `fetchpriority` attribute,
+     * including string, UnitEnum, and `null`, as well as replacement scenarios.
+     *
+     * Each test case includes the input value, the initial attributes, the expected value, and an assertion message for
+     * clear identification.
+     *
+     * @return array Test data for `fetchpriority` attribute scenarios.
+     *
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataGenerator::cases(Fetchpriority::class, Attribute::FETCHPRIORITY);
+
+        $staticCase = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'high',
+                ['fetchpriority' => 'low'],
+                'high',
+                ' fetchpriority="high"',
+                "Should return new 'fetchpriority' after replacing the existing 'fetchpriority' attribute.",
+            ],
+            'string' => [
+                'high',
+                [],
+                'high',
+                ' fetchpriority="high"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['fetchpriority' => 'high'],
+                '',
+                '',
+                "Should unset the 'fetchpriority' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fetchpriority attribute support for HTML/SVG with three priorities (auto, high, low) and an immutable API to set/unset it.

* **Tests**
  * Added comprehensive tests covering rendering, immutability, valid values, and invalid-value errors.

* **Documentation**
  * Changelog updated documenting the new fetchpriority capability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->