### PR TITLE
fix(tests): Update attribute retrieval in tests to use `getAttribute()` method for consistency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Enh #20: Add `HasDecoding` trait and `decoding()` method to manage `decoding` attribute for HTML/SVG elements (@terabytesoftw)
 - Enh #21: Add `HasFetchpriority` trait and `fetchpriority()` method to manage `fetchpriority` attribute for HTML/SVG elements (@terabytesoftw)
 - Bug #22: Update documentation for `Crossorigin` and `ElementAttribute` enums to clarify attribute representation and compliance with MDN standards (@terabytesoftw)
+- Bug #23: Update attribute retrieval in tests to use `getAttribute()` method for consistency (@terabytesoftw)
 
 ## 0.4.0 December 27, 2025
 

--- a/tests/Element/HasAltTest.php
+++ b/tests/Element/HasAltTest.php
@@ -81,7 +81,7 @@ final class HasAltTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(ElementAttribute::ALT->value, null),
+            $instance->getAttribute(ElementAttribute::ALT, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasAltTest.php
+++ b/tests/Element/HasAltTest.php
@@ -81,7 +81,7 @@ final class HasAltTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[ElementAttribute::ALT->value] ?? '',
+            $instance->getAttribute(ElementAttribute::ALT->value, null),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasDecodingTest.php
+++ b/tests/Element/HasDecodingTest.php
@@ -85,7 +85,7 @@ final class HasDecodingTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[ElementAttribute::DECODING->value] ?? '',
+            $instance->getAttribute(ElementAttribute::DECODING->value, null),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasDecodingTest.php
+++ b/tests/Element/HasDecodingTest.php
@@ -85,7 +85,7 @@ final class HasDecodingTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(ElementAttribute::DECODING->value, null),
+            $instance->getAttribute(ElementAttribute::DECODING, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasHeightTest.php
+++ b/tests/Element/HasHeightTest.php
@@ -81,7 +81,7 @@ final class HasHeightTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[ElementAttribute::HEIGHT->value] ?? '',
+            $instance->getAttribute(ElementAttribute::HEIGHT->value, null),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasHeightTest.php
+++ b/tests/Element/HasHeightTest.php
@@ -81,7 +81,7 @@ final class HasHeightTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(ElementAttribute::HEIGHT->value, null),
+            $instance->getAttribute(ElementAttribute::HEIGHT, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasHrefTest.php
+++ b/tests/Element/HasHrefTest.php
@@ -81,7 +81,7 @@ final class HasHrefTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(ElementAttribute::HREF->value, null),
+            $instance->getAttribute(ElementAttribute::HREF, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasHrefTest.php
+++ b/tests/Element/HasHrefTest.php
@@ -81,7 +81,7 @@ final class HasHrefTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[ElementAttribute::HREF->value] ?? '',
+            $instance->getAttribute(ElementAttribute::HREF->value, null),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasReferrerpolicyTest.php
+++ b/tests/Element/HasReferrerpolicyTest.php
@@ -84,7 +84,7 @@ final class HasReferrerpolicyTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[ElementAttribute::REFERRERPOLICY->value] ?? '',
+            $instance->getAttribute(ElementAttribute::REFERRERPOLICY->value, null),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasReferrerpolicyTest.php
+++ b/tests/Element/HasReferrerpolicyTest.php
@@ -84,7 +84,7 @@ final class HasReferrerpolicyTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(ElementAttribute::REFERRERPOLICY->value, null),
+            $instance->getAttribute(ElementAttribute::REFERRERPOLICY, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasSrcTest.php
+++ b/tests/Element/HasSrcTest.php
@@ -81,7 +81,7 @@ final class HasSrcTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[ElementAttribute::SRC->value] ?? '',
+            $instance->getAttribute(ElementAttribute::SRC->value, null),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasSrcTest.php
+++ b/tests/Element/HasSrcTest.php
@@ -81,7 +81,7 @@ final class HasSrcTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(ElementAttribute::SRC->value, null),
+            $instance->getAttribute(ElementAttribute::SRC, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasWidthTest.php
+++ b/tests/Element/HasWidthTest.php
@@ -81,7 +81,7 @@ final class HasWidthTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[ElementAttribute::WIDTH->value] ?? '',
+            $instance->getAttribute(ElementAttribute::WIDTH, null),
             $message,
         );
         self::assertSame(

--- a/tests/Element/HasWidthTest.php
+++ b/tests/Element/HasWidthTest.php
@@ -81,7 +81,7 @@ final class HasWidthTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(ElementAttribute::WIDTH, null),
+            $instance->getAttribute(ElementAttribute::WIDTH, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/CanBeAutofocusTest.php
+++ b/tests/Global/CanBeAutofocusTest.php
@@ -82,7 +82,7 @@ final class CanBeAutofocusTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::AUTOFOCUS, null),
+            $instance->getAttribute(GlobalAttribute::AUTOFOCUS, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/CanBeAutofocusTest.php
+++ b/tests/Global/CanBeAutofocusTest.php
@@ -82,7 +82,7 @@ final class CanBeAutofocusTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::AUTOFOCUS->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::AUTOFOCUS, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/CanBeHiddenTest.php
+++ b/tests/Global/CanBeHiddenTest.php
@@ -81,7 +81,7 @@ final class CanBeHiddenTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::HIDDEN->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::HIDDEN, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/CanBeHiddenTest.php
+++ b/tests/Global/CanBeHiddenTest.php
@@ -81,7 +81,7 @@ final class CanBeHiddenTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::HIDDEN, null),
+            $instance->getAttribute(GlobalAttribute::HIDDEN, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasAccesskeyTest.php
+++ b/tests/Global/HasAccesskeyTest.php
@@ -82,7 +82,7 @@ final class HasAccesskeyTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::ACCESSKEY, null),
+            $instance->getAttribute(GlobalAttribute::ACCESSKEY, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasAccesskeyTest.php
+++ b/tests/Global/HasAccesskeyTest.php
@@ -82,7 +82,7 @@ final class HasAccesskeyTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::ACCESSKEY->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::ACCESSKEY, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasClassTest.php
+++ b/tests/Global/HasClassTest.php
@@ -89,7 +89,7 @@ final class HasClassTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::CLASS_CSS->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::CLASS_CSS, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasClassTest.php
+++ b/tests/Global/HasClassTest.php
@@ -89,7 +89,7 @@ final class HasClassTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::CLASS_CSS, null),
+            $instance->getAttribute(GlobalAttribute::CLASS_CSS, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasContentEditableTest.php
+++ b/tests/Global/HasContentEditableTest.php
@@ -85,7 +85,7 @@ final class HasContentEditableTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::CONTENTEDITABLE->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::CONTENTEDITABLE, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasContentEditableTest.php
+++ b/tests/Global/HasContentEditableTest.php
@@ -85,7 +85,7 @@ final class HasContentEditableTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::CONTENTEDITABLE, null),
+            $instance->getAttribute(GlobalAttribute::CONTENTEDITABLE, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasDirTest.php
+++ b/tests/Global/HasDirTest.php
@@ -84,7 +84,7 @@ final class HasDirTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::DIR, null),
+            $instance->getAttribute(GlobalAttribute::DIR, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasDirTest.php
+++ b/tests/Global/HasDirTest.php
@@ -84,7 +84,7 @@ final class HasDirTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::DIR->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::DIR, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasDraggableTest.php
+++ b/tests/Global/HasDraggableTest.php
@@ -85,7 +85,7 @@ final class HasDraggableTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::DRAGGABLE, null),
+            $instance->getAttribute(GlobalAttribute::DRAGGABLE, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasDraggableTest.php
+++ b/tests/Global/HasDraggableTest.php
@@ -85,7 +85,7 @@ final class HasDraggableTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::DRAGGABLE->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::DRAGGABLE, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasIdTest.php
+++ b/tests/Global/HasIdTest.php
@@ -81,7 +81,7 @@ final class HasIdTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::ID->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::ID, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasIdTest.php
+++ b/tests/Global/HasIdTest.php
@@ -81,7 +81,7 @@ final class HasIdTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::ID, null),
+            $instance->getAttribute(GlobalAttribute::ID, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasLangTest.php
+++ b/tests/Global/HasLangTest.php
@@ -84,7 +84,7 @@ final class HasLangTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::LANG, null),
+            $instance->getAttribute(GlobalAttribute::LANG, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasLangTest.php
+++ b/tests/Global/HasLangTest.php
@@ -84,7 +84,7 @@ final class HasLangTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::LANG->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::LANG, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasMicroDataTest.php
+++ b/tests/Global/HasMicroDataTest.php
@@ -145,7 +145,7 @@ final class HasMicroDataTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::ITEMID, null),
+            $instance->getAttribute(GlobalAttribute::ITEMID, ''),
             $message,
         );
         self::assertSame(
@@ -175,7 +175,7 @@ final class HasMicroDataTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::ITEMPROP, null),
+            $instance->getAttribute(GlobalAttribute::ITEMPROP, ''),
             $message,
         );
         self::assertSame(
@@ -205,7 +205,7 @@ final class HasMicroDataTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::ITEMREF, null),
+            $instance->getAttribute(GlobalAttribute::ITEMREF, ''),
             $message,
         );
         self::assertSame(
@@ -235,7 +235,7 @@ final class HasMicroDataTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::ITEMSCOPE, null),
+            $instance->getAttribute(GlobalAttribute::ITEMSCOPE, ''),
             $message,
         );
         self::assertSame(
@@ -265,7 +265,7 @@ final class HasMicroDataTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::ITEMTYPE, null),
+            $instance->getAttribute(GlobalAttribute::ITEMTYPE, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasMicroDataTest.php
+++ b/tests/Global/HasMicroDataTest.php
@@ -145,7 +145,7 @@ final class HasMicroDataTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::ITEMID->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::ITEMID, null),
             $message,
         );
         self::assertSame(
@@ -175,7 +175,7 @@ final class HasMicroDataTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::ITEMPROP->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::ITEMPROP, null),
             $message,
         );
         self::assertSame(
@@ -205,7 +205,7 @@ final class HasMicroDataTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::ITEMREF->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::ITEMREF, null),
             $message,
         );
         self::assertSame(
@@ -235,7 +235,7 @@ final class HasMicroDataTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::ITEMSCOPE->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::ITEMSCOPE, null),
             $message,
         );
         self::assertSame(
@@ -265,7 +265,7 @@ final class HasMicroDataTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::ITEMTYPE->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::ITEMTYPE, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasRoleTest.php
+++ b/tests/Global/HasRoleTest.php
@@ -84,7 +84,7 @@ final class HasRoleTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::ROLE, null),
+            $instance->getAttribute(GlobalAttribute::ROLE, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasRoleTest.php
+++ b/tests/Global/HasRoleTest.php
@@ -84,7 +84,7 @@ final class HasRoleTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::ROLE->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::ROLE, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasSpellcheckTest.php
+++ b/tests/Global/HasSpellcheckTest.php
@@ -84,7 +84,7 @@ final class HasSpellcheckTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::SPELLCHECK->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::SPELLCHECK, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasSpellcheckTest.php
+++ b/tests/Global/HasSpellcheckTest.php
@@ -84,7 +84,7 @@ final class HasSpellcheckTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::SPELLCHECK, null),
+            $instance->getAttribute(GlobalAttribute::SPELLCHECK, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasStyleTest.php
+++ b/tests/Global/HasStyleTest.php
@@ -85,7 +85,7 @@ final class HasStyleTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::STYLE->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::STYLE, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasStyleTest.php
+++ b/tests/Global/HasStyleTest.php
@@ -85,7 +85,7 @@ final class HasStyleTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::STYLE, null),
+            $instance->getAttribute(GlobalAttribute::STYLE, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasTabIndexTest.php
+++ b/tests/Global/HasTabIndexTest.php
@@ -85,7 +85,7 @@ final class HasTabIndexTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::TABINDEX->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::TABINDEX, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasTabIndexTest.php
+++ b/tests/Global/HasTabIndexTest.php
@@ -85,7 +85,7 @@ final class HasTabIndexTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::TABINDEX, null),
+            $instance->getAttribute(GlobalAttribute::TABINDEX, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasTitleTest.php
+++ b/tests/Global/HasTitleTest.php
@@ -83,7 +83,7 @@ final class HasTitleTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::TITLE->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::TITLE, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasTitleTest.php
+++ b/tests/Global/HasTitleTest.php
@@ -83,7 +83,7 @@ final class HasTitleTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::TITLE, null),
+            $instance->getAttribute(GlobalAttribute::TITLE, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasTranslateTest.php
+++ b/tests/Global/HasTranslateTest.php
@@ -85,7 +85,7 @@ final class HasTranslateTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[GlobalAttribute::TRANSLATE->value] ?? '',
+            $instance->getAttribute(GlobalAttribute::TRANSLATE, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/HasTranslateTest.php
+++ b/tests/Global/HasTranslateTest.php
@@ -85,7 +85,7 @@ final class HasTranslateTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::TRANSLATE, null),
+            $instance->getAttribute(GlobalAttribute::TRANSLATE, ''),
             $message,
         );
         self::assertSame(

--- a/tests/HasCrossoriginTest.php
+++ b/tests/HasCrossoriginTest.php
@@ -85,7 +85,7 @@ final class HasCrossoriginTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[Attribute::CROSSORIGIN->value] ?? '',
+            $instance->getAttribute(Attribute::CROSSORIGIN->value, null),
             $message,
         );
         self::assertSame(

--- a/tests/HasCrossoriginTest.php
+++ b/tests/HasCrossoriginTest.php
@@ -85,7 +85,7 @@ final class HasCrossoriginTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(Attribute::CROSSORIGIN->value, null),
+            $instance->getAttribute(Attribute::CROSSORIGIN, ''),
             $message,
         );
         self::assertSame(

--- a/tests/HasFetchpriorityTest.php
+++ b/tests/HasFetchpriorityTest.php
@@ -85,7 +85,7 @@ final class HasFetchpriorityTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(Attribute::FETCHPRIORITY->value, null),
+            $instance->getAttribute(Attribute::FETCHPRIORITY, ''),
             $message,
         );
         self::assertSame(

--- a/tests/HasFetchpriorityTest.php
+++ b/tests/HasFetchpriorityTest.php
@@ -85,7 +85,7 @@ final class HasFetchpriorityTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[Attribute::FETCHPRIORITY->value] ?? '',
+            $instance->getAttribute(Attribute::FETCHPRIORITY->value, null),
             $message,
         );
         self::assertSame(

--- a/tests/HasRelTest.php
+++ b/tests/HasRelTest.php
@@ -84,7 +84,7 @@ final class HasRelTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(Attribute::REL->value, null),
+            $instance->getAttribute(Attribute::REL, ''),
             $message,
         );
         self::assertSame(

--- a/tests/HasRelTest.php
+++ b/tests/HasRelTest.php
@@ -84,7 +84,7 @@ final class HasRelTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttributes()[Attribute::REL->value] ?? '',
+            $instance->getAttribute(Attribute::REL->value, null),
             $message,
         );
         self::assertSame(


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated many test assertions to consistently use the public attribute accessor when reading attribute values, aligning access patterns across the suite.
  * Observable behavior and rendered outputs remain unchanged; changes are limited to test code and improve encapsulation and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->