### PR TITLE
feat(attribute): Add `HasBlocking` trait and `blocking()` method to manage `blocking` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.5.3 Under development
 
+- Enh #32: Add `HasBlocking` trait and `blocking()` method to manage `blocking` attribute for HTML elements (@terabytesoftw)
+
 ## 0.5.2 January 29, 2026
 
 - Enh #28: Add `php-forge/coding-standard` to development dependencies for code quality checks (@terabytesoftw)
@@ -15,14 +17,14 @@
 
 ## 0.5.0 January 19, 2026
 
-- Enh #14: Add `HasHref` trait and `href()` method to manage `href` attribute for HTML/SVG elements (@terabytesoftw)
-- Enh #15: Add `HasCrossorigin` trait and `crossorigin()` method to manage `crossorigin` attribute for HTML/SVG elements (@terabytesoftw)
+- Enh #14: Add `HasHref` trait and `href()` method to manage `href` attribute for HTML elements (@terabytesoftw)
+- Enh #15: Add `HasCrossorigin` trait and `crossorigin()` method to manage `crossorigin` attribute for HTML elements (@terabytesoftw)
 - Enh #16: Use package `ui-awesome/html-mixin` for mixin traits and update related imports accordingly (@terabytesoftw)
 - Enh #17: Add development guide and sync metadata instructions and update testing documentation (@terabytesoftw)
 - Enh #18: Move attribute traits from `ui-awesome/html-core` package and update related imports accordingly (@terabytesoftw)
 - Bug #19: Update alert content in SVGs to reflect accurate descriptions for MDN standards compliance and specific & lightweight features (@terabytesoftw)
-- Enh #20: Add `HasDecoding` trait and `decoding()` method to manage `decoding` attribute for HTML/SVG elements (@terabytesoftw)
-- Enh #21: Add `HasFetchpriority` trait and `fetchpriority()` method to manage `fetchpriority` attribute for HTML/SVG elements (@terabytesoftw)
+- Enh #20: Add `HasDecoding` trait and `decoding()` method to manage `decoding` attribute for HTML elements (@terabytesoftw)
+- Enh #21: Add `HasFetchpriority` trait and `fetchpriority()` method to manage `fetchpriority` attribute for HTML elements (@terabytesoftw)
 - Bug #22: Update documentation for `Crossorigin` and `ElementAttribute` enums to clarify attribute representation and compliance with MDN standards (@terabytesoftw)
 - Bug #23: Update attribute retrieval in tests to use `getAttribute()` method for consistency (@terabytesoftw)
 - Bug #24: Update documentation traits and enums for clarity and consistency (@terabytesoftw)

--- a/src/HasBlocking.php
+++ b/src/HasBlocking.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\{Attribute, Blocking};
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `blocking` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `blocking` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `blocking` attribute and value validation.
+ *
+ * Key features.
+ * - Designed for use in link, script, and style elements.
+ * - Handles the HTML `blocking` attribute.
+ * - Immutable method for setting or overriding the `blocking` attribute.
+ * - Supports string, UnitEnum, and `null` for flexible token assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style#blocking
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasBlocking
+{
+    /**
+     * Sets the HTML `blocking` attribute for the element.
+     *
+     * Creates a new instance with the specified token value, supporting explicit assignment according to the
+     * specification-defined token set.
+     *
+     * @param string|UnitEnum|null $value Token value to set for the element. Use a valid token (for example, `render`).
+     * Can be `null` to unset the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `blocking` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->blocking('render');
+     * $element->blocking(Blocking::RENDER);
+     * $element->blocking(null);
+     * ```
+     */
+    public function blocking(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, Blocking::cases(), Attribute::BLOCKING);
+
+        return $this->addAttribute(Attribute::BLOCKING, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -37,6 +37,13 @@ enum Attribute: string
     case AUTOCOMPLETE = 'autocomplete';
 
     /**
+     * `blocking` — Indicates that certain operations should be blocked on the fetching of an external resource.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style#blocking
+     */
+    case BLOCKING = 'blocking';
+
+    /**
      * `capture` — Media capture hint for file inputs.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/capture

--- a/src/Values/Blocking.php
+++ b/src/Values/Blocking.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents values for the HTML `blocking` attribute.
+ *
+ * Defines the supported `blocking` tokens as enum cases.
+ *
+ * Key features.
+ * - Designed for use in link, script, and style elements.
+ * - Enum values map to the attribute tokens used in markup.
+ * - Suitable for rendering HTML attributes in view helpers and components.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style#blocking
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Blocking: string
+{
+    /**
+     * `render` - Blocks rendering until the resource is fetched.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style#blocking
+     */
+    case RENDER = 'render';
+}

--- a/tests/HasBlockingTest.php
+++ b/tests/HasBlockingTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasBlocking;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\BlockingProvider;
+use UIAwesome\Html\Attribute\Values\{Attribute, Blocking};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasBlocking} trait managing the `blocking` HTML attribute.
+ *
+ * Verifies rendered output, immutability, attribute override, and validation behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `blocking` attribute is not provided.
+ * - Sets the `blocking` HTML attribute and renders the expected output.
+ * - Throws an exception when the `blocking` attribute value is invalid.
+ *
+ * {@see BlockingProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasBlockingTest extends TestCase
+{
+    public function testReturnEmptyWhenBlockingAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasBlocking;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingBlockingAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasBlocking;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->blocking(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(BlockingProvider::class, 'values')]
+    public function testSetBlockingAttributeValue(
+        string|UnitEnum|null $blocking,
+        array $attributes,
+        string|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasBlocking;
+        };
+
+        $instance = $instance->attributes($attributes)->blocking($blocking);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::BLOCKING, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testThrowExceptionWhenSettingInvalidBlockingValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasBlocking;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                Attribute::BLOCKING->value,
+                implode('\', \'', Enum::normalizeArray(Blocking::cases())),
+            ),
+        );
+
+        $instance->blocking('invalid-value');
+    }
+}

--- a/tests/Support/Provider/BlockingProvider.php
+++ b/tests/Support/Provider/BlockingProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use PHPForge\Support\EnumDataProvider;
+use UIAwesome\Html\Attribute\Values\{Attribute, Blocking};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasBlockingTest} test cases.
+ *
+ * Provides representative input/output pairs for the `blocking` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class BlockingProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataProvider::attributeCases(Blocking::class, Attribute::BLOCKING);
+
+        $staticCase = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'render',
+                ['blocking' => 'invalid'],
+                'render',
+                ' blocking="render"',
+                "Should return new 'blocking' after replacing the existing 'blocking' attribute.",
+            ],
+            'string' => [
+                'render',
+                [],
+                'render',
+                ' blocking="render"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['blocking' => 'render'],
+                '',
+                '',
+                "Should unset the 'blocking' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the blocking attribute on HTML elements with an immutable, type-safe API.

* **Documentation**
  * Clarified documentation to reference HTML elements (removed SVG-specific wording) for related attributes.

* **Tests**
  * Added comprehensive tests and data providers to validate blocking attribute behavior, rendering, and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->