### PR TITLE
feat(attribute): Add `HasMedia` trait and `media()` method to manage `media` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.5.3 Under development
 
 - Enh #32: Add `HasBlocking` trait and `blocking()` method to manage `blocking` attribute for HTML elements (@terabytesoftw)
+- Enh #33: Add `HasMedia` trait and `media()` method to manage `media` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasBlocking.php
+++ b/src/HasBlocking.php
@@ -35,8 +35,8 @@ trait HasBlocking
     /**
      * Sets the HTML `blocking` attribute for the element.
      *
-     * Creates a new instance with the specified token value, supporting explicit assignment according to the
-     * specification-defined token set.
+     * Creates a new instance with the specified blocking token value, supporting explicit assignment according to the
+     * HTML specification for blocking attributes.
      *
      * @param string|UnitEnum|null $value Token value to set for the element. Use a valid token (for example, `render`).
      * Can be `null` to unset the attribute.

--- a/src/HasMedia.php
+++ b/src/HasMedia.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `media` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `media` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `media` attribute.
+ *
+ * Key features.
+ * - Designed for use in link, style, and source elements.
+ * - Handles the HTML `media` attribute.
+ * - Immutable method for setting or overriding the `media` attribute.
+ * - Supports string, Stringable, UnitEnum, and `null` for flexible media query assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/media
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasMedia
+{
+    /**
+     * Sets the HTML `media` attribute for the element.
+     *
+     * Creates a new instance with the specified media query value, supporting explicit assignment according to the
+     * HTML specification for media attributes.
+     *
+     * @param string|Stringable|UnitEnum|null $value Media query value to set for the element. Can be `null` to unset
+     * the attribute.
+     *
+     * @return static New instance with the updated `media` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->media('screen');
+     * $element->media(null);
+     * ```
+     */
+    public function media(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::MEDIA, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -121,6 +121,13 @@ enum Attribute: string
     case MAXLENGTH = 'maxlength';
 
     /**
+     * `media` — Specifies the media that the linked resource applies to.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/media
+     */
+    case MEDIA = 'media';
+
+    /**
      * `min` — Indicates the minimum value allowed.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/min

--- a/tests/HasMediaTest.php
+++ b/tests/HasMediaTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasMedia;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\MediaProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasMedia} trait managing the `media` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `media` attribute is not provided.
+ * - Sets the `media` HTML attribute and renders the expected output.
+ *
+ * {@see MediaProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasMediaTest extends TestCase
+{
+    public function testReturnEmptyWhenMediaAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasMedia;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingMediaAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasMedia;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->media(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(MediaProvider::class, 'values')]
+    public function testSetMediaAttributeValue(
+        string|Stringable|UnitEnum|null $media,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasMedia;
+        };
+
+        $instance = $instance->attributes($attributes)->media($media);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::MEDIA, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/MediaProvider.php
+++ b/tests/Support/Provider/MediaProvider.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Tests\Support\Stub\Values\Status;
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasMediaTest} test cases.
+ *
+ * Provides representative input/output pairs for the `media` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class MediaProvider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{string|Stringable|UnitEnum|null, mixed[], string|Stringable|UnitEnum, string, string}
+     * >
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'screen';
+            }
+        };
+
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'enum' => [
+                Status::ACTIVE,
+                [],
+                Status::ACTIVE,
+                ' media="active"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'print',
+                ['media' => 'screen'],
+                'print',
+                ' media="print"',
+                "Should return new 'media' after replacing the existing 'media' attribute.",
+            ],
+            'string' => [
+                'screen',
+                [],
+                'screen',
+                ' media="screen"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' media="screen"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['media' => 'screen'],
+                '',
+                '',
+                "Should unset the 'media' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the media attribute on HTML elements with a fluent, immutable API for setting and unsetting values.

* **Documentation**
  * Enhanced blocking attribute documentation with specification references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->