### PR TITLE
feat(attribute): Add `HasType` trait and `type()` method to manage `type` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enh #32: Add `HasBlocking` trait and `blocking()` method to manage `blocking` attribute for HTML elements (@terabytesoftw)
 - Enh #33: Add `HasMedia` trait and `media()` method to manage `media` attribute for HTML elements (@terabytesoftw)
+- Enh #34: Add `HasType` trait and `type()` method to manage `type` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasType.php
+++ b/src/HasType.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `type` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `type` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `type` attribute.
+ *
+ * Key features.
+ * - Designed for use in style, script, and input elements.
+ * - Handles the HTML `type` attribute.
+ * - Immutable method for setting or overriding the `type` attribute.
+ * - Supports string, Stringable, UnitEnum, and `null` for flexible type assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/type
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasType
+{
+    /**
+     * Sets the HTML `type` attribute for the element.
+     *
+     * Creates a new instance with the specified type value, supporting explicit assignment according to the HTML
+     * specification for type attributes.
+     *
+     * @param string|Stringable|UnitEnum|null $value Type value to set for the element. Can be `null` to unset the
+     * attribute.
+     *
+     * @return static New instance with the updated `type` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->type('text/css');
+     * $element->type(null);
+     * ```
+     */
+    public function type(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::TYPE, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -196,4 +196,11 @@ enum Attribute: string
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/step
      */
     case STEP = 'step';
+
+    /**
+     * `type` — Defines the type of the element.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/type
+     */
+    case TYPE = 'type';
 }

--- a/tests/HasTypeTest.php
+++ b/tests/HasTypeTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasType;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\TypeProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasType} trait managing the `type` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `type` attribute is not provided.
+ * - Sets the `type` HTML attribute and renders the expected output.
+ *
+ * {@see TypeProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasTypeTest extends TestCase
+{
+    public function testReturnEmptyWhenTypeAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasType;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingTypeAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasType;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->type(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(TypeProvider::class, 'values')]
+    public function testSetTypeAttributeValue(
+        string|Stringable|UnitEnum|null $type,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasType;
+        };
+
+        $instance = $instance->attributes($attributes)->type($type);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::TYPE, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/TypeProvider.php
+++ b/tests/Support/Provider/TypeProvider.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Tests\Support\Stub\Values\Status;
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasTypeTest} test cases.
+ *
+ * Provides representative input/output pairs for the `type` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TypeProvider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{string|Stringable|UnitEnum|null, mixed[], string|Stringable|UnitEnum, string, string}
+     * >
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'text/css';
+            }
+        };
+
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'enum' => [
+                Status::ACTIVE,
+                [],
+                Status::ACTIVE,
+                ' type="active"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'text/css',
+                ['type' => 'text/plain'],
+                'text/css',
+                ' type="text/css"',
+                "Should return new 'type' after replacing the existing 'type' attribute.",
+            ],
+            'string' => [
+                'text/plain',
+                [],
+                'text/plain',
+                ' type="text/plain"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' type="text/css"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['type' => 'text/css'],
+                '',
+                '',
+                "Should unset the 'type' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing the HTML type attribute on elements with flexible input handling for strings, Stringable objects, enums, and null values.

* **Tests**
  * Added comprehensive test coverage for type attribute functionality, including immutability and rendering validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->