### PR TITLE
feat(attribute): Add `HasNonce` trait and `nonce()` method to manage `nonce` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enh #32: Add `HasBlocking` trait and `blocking()` method to manage `blocking` attribute for HTML elements (@terabytesoftw)
 - Enh #33: Add `HasMedia` trait and `media()` method to manage `media` attribute for HTML elements (@terabytesoftw)
 - Enh #34: Add `HasType` trait and `type()` method to manage `type` attribute for HTML elements (@terabytesoftw)
+- Enh #35: Add `HasNonce` trait and `nonce()` method to manage `nonce` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/Global/HasNonce.php
+++ b/src/Global/HasNonce.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Global;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\GlobalAttribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the global HTML `nonce` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `nonce` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of cryptographic nonces.
+ *
+ * Key features.
+ * - Designed for use in tags and components.
+ * - Handles the HTML `nonce` global attribute.
+ * - Immutable method for setting or overriding the `nonce` attribute.
+ * - Supports string, Stringable, UnitEnum, and `null` for flexible nonce assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/nonce
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasNonce
+{
+    /**
+     * Sets the HTML `nonce` attribute for the element.
+     *
+     * Creates a new instance with the specified nonce value, supporting explicit assignment according to the HTML
+     * specification for global attributes.
+     *
+     * @param string|Stringable|UnitEnum|null $value Nonce value to set for the element. Can be `null` to unset the
+     * attribute.
+     *
+     * @return static New instance with the updated `nonce` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->nonce('nonce-value');
+     * $element->nonce(null);
+     * ```
+     */
+    public function nonce(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(GlobalAttribute::NONCE, $value);
+    }
+}

--- a/tests/Global/HasNonceTest.php
+++ b/tests/Global/HasNonceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Global;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\Global\HasNonce;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\Global\NonceProvider;
+use UIAwesome\Html\Attribute\Values\GlobalAttribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasNonce} trait managing the `nonce` global HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `nonce` attribute is not provided.
+ * - Sets the `nonce` global HTML attribute and renders the expected output.
+ *
+ * {@see NonceProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('global')]
+final class HasNonceTest extends TestCase
+{
+    public function testReturnEmptyWhenNonceAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasNonce;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingNonceAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasNonce;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->nonce(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(NonceProvider::class, 'values')]
+    public function testSetNonceAttributeValue(
+        string|Stringable|UnitEnum|null $nonce,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttribute,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasNonce;
+        };
+
+        $instance = $instance->attributes($attributes)->nonce($nonce);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(GlobalAttribute::NONCE, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttribute,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/Global/NonceProvider.php
+++ b/tests/Support/Provider/Global/NonceProvider.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider\Global;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Tests\Support\Stub\Values\Status;
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Global\HasNonceTest} test cases.
+ *
+ * Provides representative input/output pairs for the `nonce` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class NonceProvider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{string|Stringable|UnitEnum|null, mixed[], string|Stringable|UnitEnum, string, string}
+     * >
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'nonce-value';
+            }
+        };
+
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'enum' => [
+                Status::ACTIVE,
+                [],
+                Status::ACTIVE,
+                ' nonce="active"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'nonce-2',
+                ['nonce' => 'nonce-1'],
+                'nonce-2',
+                ' nonce="nonce-2"',
+                "Should return new 'nonce' after replacing the existing 'nonce' attribute.",
+            ],
+            'string' => [
+                'nonce-value',
+                [],
+                'nonce-value',
+                ' nonce="nonce-value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' nonce="nonce-value"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['nonce' => 'nonce-value'],
+                '',
+                '',
+                "Should unset the 'nonce' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for managing nonce attributes on HTML elements through a new immutable trait with chainable methods. Supports string, Stringable, UnitEnum values, and null for unsetting.

* **Tests**
  * Comprehensive test suite added covering immutability, empty states, attribute storage, rendering output, and various input types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->