### PR TITLE
feat(attribute): Add `HasIntegrity` trait and `integrity()` method to manage `integrity` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enh #34: Add `HasType` trait and `type()` method to manage `type` attribute for HTML elements (@terabytesoftw)
 - Enh #35: Add `HasNonce` trait and `nonce()` method to manage `nonce` attribute for HTML elements (@terabytesoftw)
 - Bug #36: Clarify documentation for various HTML attributes to specify value types for better understanding (@terabytesoftw)
+- Enh #37: Add `HasIntegrity` trait and `integrity()` method to manage `integrity` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasIntegrity.php
+++ b/src/HasIntegrity.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `integrity` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `integrity` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the Subresource Integrity attribute.
+ *
+ * Key features.
+ * - Designed for use in script and link elements.
+ * - Handles the HTML `integrity` attribute for Subresource Integrity (SRI).
+ * - Immutable method for setting or overriding the `integrity` attribute.
+ * - Supports string, Stringable, UnitEnum, and `null` for flexible integrity assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/integrity
+ * @link https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasIntegrity
+{
+    /**
+     * Sets the HTML `integrity` attribute for the element.
+     *
+     * Creates a new instance with the specified integrity metadata value, supporting explicit assignment according to
+     * the Subresource Integrity specification. The value should contain the cryptographic hash(es) of the resource.
+     *
+     * @param string|Stringable|UnitEnum|null $value Integrity metadata value to set for the element. Typically contains
+     * a hash algorithm and base64-encoded hash (for example, `sha384-abc123...`). Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `integrity` attribute.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+     *
+     * Usage example:
+     * ```php
+     * $element->integrity('sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC');
+     * $element->integrity(null);
+     * ```
+     */
+    public function integrity(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::INTEGRITY, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -107,6 +107,14 @@ enum Attribute: string
     case FORM = 'form';
 
     /**
+     * `integrity` — Contains inline metadata that a user agent can use to verify that a fetched resource has been
+     * delivered without unexpected manipulation (Subresource Integrity).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/integrity
+     */
+    case INTEGRITY = 'integrity';
+
+    /**
      * `max` — Indicates the maximum value allowed.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/max

--- a/tests/HasIntegrityTest.php
+++ b/tests/HasIntegrityTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasIntegrity;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\IntegrityProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasIntegrity} trait managing the `integrity` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `integrity` attribute is not provided.
+ * - Sets the `integrity` HTML attribute and renders the expected output.
+ *
+ * {@see IntegrityProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasIntegrityTest extends TestCase
+{
+    public function testReturnEmptyWhenIntegrityAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasIntegrity;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingIntegrityAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasIntegrity;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->integrity(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(IntegrityProvider::class, 'values')]
+    public function testSetIntegrityAttributeValue(
+        string|UnitEnum|null $integrity,
+        array $attributes,
+        string|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasIntegrity;
+        };
+
+        $instance = $instance->attributes($attributes)->integrity($integrity);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::INTEGRITY, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/IntegrityProvider.php
+++ b/tests/Support/Provider/IntegrityProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasIntegrityTest} test cases.
+ *
+ * Provides representative input/output pairs for the `integrity` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class IntegrityProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'sha384-newhash',
+                ['integrity' => 'sha384-oldhash'],
+                'sha384-newhash',
+                ' integrity="sha384-newhash"',
+                "Should return new 'integrity' after replacing the existing 'integrity' attribute.",
+            ],
+            'string' => [
+                'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC',
+                [],
+                'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC',
+                ' integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['integrity' => 'sha384-abc123'],
+                '',
+                '',
+                "Should unset the 'integrity' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new capability to manage the HTML integrity attribute on elements using an immutable API method. This enables Subresource Integrity (SRI) verification on script and link tags, allowing validation of external resource authenticity and integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->