### PR TITLE
feat(attribute): Add `HasSrc` trait and `src()` method to manage `src` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #36: Clarify documentation for various HTML attributes to specify value types for better understanding (@terabytesoftw)
 - Enh #37: Add `HasIntegrity` trait and `integrity()` method to manage `integrity` attribute for HTML elements (@terabytesoftw)
 - Enh #38: Add `HasReferrerpolicy` trait and `referrerpolicy()` method to manage `referrerpolicy` attribute for HTML elements (@terabytesoftw)
+- Enh #39: Add `HasSrc` trait and `src()` method to manage `src` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasSrc.php
+++ b/src/HasSrc.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `src` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `src` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the source URL attribute.
+ *
+ * Key features.
+ * - Designed for use in script, img, video, audio, iframe, input, source, track, and embed elements.
+ * - Handles the HTML `src` attribute.
+ * - Immutable method for setting or overriding the `src` attribute.
+ * - Supports string, Stringable, UnitEnum, and `null` for flexible source assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/src
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasSrc
+{
+    /**
+     * Sets the HTML `src` attribute for the element.
+     *
+     * Creates a new instance with the specified source URL value, supporting explicit assignment according to the
+     * HTML specification for src attributes.
+     *
+     * @param string|Stringable|UnitEnum|null $value Source URL value to set for the element. Can be `null` to unset the
+     * attribute.
+     *
+     * @return static New instance with the updated `src` attribute.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/src
+     *
+     * Usage example:
+     * ```php
+     * $element->src('https://example.com/script.js');
+     * $element->src(null);
+     * ```
+     */
+    public function src(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::SRC, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -206,6 +206,13 @@ enum Attribute: string
     case SIZE = 'size';
 
     /**
+     * `src` — Specifies the URL of the resource.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/src
+     */
+    case SRC = 'src';
+
+    /**
      * `step` — Defines the granularity of the value in an input of type number or range.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/step

--- a/tests/HasSrcTest.php
+++ b/tests/HasSrcTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasSrc;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\SrcProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasSrc} trait managing the `src` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `src` attribute is not provided.
+ * - Sets the `src` HTML attribute and renders the expected output.
+ *
+ * {@see SrcProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasSrcTest extends TestCase
+{
+    public function testReturnEmptyWhenSrcAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasSrc;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingSrcAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasSrc;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->src(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(SrcProvider::class, 'values')]
+    public function testSetSrcAttributeValue(
+        string|UnitEnum|null $src,
+        array $attributes,
+        string|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasSrc;
+        };
+
+        $instance = $instance->attributes($attributes)->src($src);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::SRC, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/SrcProvider.php
+++ b/tests/Support/Provider/SrcProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasSrcTest} test cases.
+ *
+ * Provides representative input/output pairs for the `src` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class SrcProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'https://example.com/new.js',
+                ['src' => 'https://example.com/old.js'],
+                'https://example.com/new.js',
+                ' src="https://example.com/new.js"',
+                "Should return new 'src' after replacing the existing 'src' attribute.",
+            ],
+            'string' => [
+                'https://example.com/script.js',
+                [],
+                'https://example.com/script.js',
+                ' src="https://example.com/script.js"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['src' => 'https://example.com/script.js'],
+                '',
+                '',
+                "Should unset the 'src' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing the `src` attribute on HTML elements with immutability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->