### PR TITLE
feat(attribute): Add `HasTarget` trait and `target()` method to manage `target` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Enh #38: Add `HasReferrerpolicy` trait and `referrerpolicy()` method to manage `referrerpolicy` attribute for HTML elements (@terabytesoftw)
 - Enh #39: Add `HasSrc` trait and `src()` method to manage `src` attribute for HTML elements (@terabytesoftw)
 - Bug #40: Enhance documentation for HTML attributes (@terabytesoftw)
+- Enh #41: Add `HasTarget` trait and `target()` method to manage `target` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasTarget.php
+++ b/src/HasTarget.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\{Attribute, Target};
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `target` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `target` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the browsing context target attribute and value
+ * validation.
+ *
+ * Key features.
+ * - Designed for use in anchor, area, base, form, and link elements.
+ * - Handles the HTML `target` attribute.
+ * - Immutable method for setting or overriding the `target` attribute.
+ * - Supports string, UnitEnum, and `null` for flexible target assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/target
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasTarget
+{
+    /**
+     * Sets the HTML `target` attribute for the element.
+     *
+     * Creates a new instance with the specified browsing context target value.
+     *
+     * Controls where to display the linked resource or where to submit the form.
+     * - Use `_self` to open in the same browsing context (default behavior).
+     * - Use `_blank` to open in a new tab or window. Always pair with `rel="noopener noreferrer"` for security.
+     * - Use `_parent` to open in the parent frame or window.
+     * - Use `_top` to open in the full, original window, breaking out of any frames.
+     *
+     * @param string|UnitEnum|null $value Target browsing context value to set for the element. Use `_self`, `_blank`,
+     * `_parent`, `_top`, or other valid browsing context names. Can be `null` to unset the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `target` attribute.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/target
+     *
+     * Usage example:
+     * ```php
+     * $element->target('_blank');
+     * $element->target(Target::BLANK);
+     * $element->target(null);
+     * ```
+     */
+    public function target(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, Target::cases(), Attribute::TARGET);
+
+        return $this->addAttribute(Attribute::TARGET, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -220,6 +220,13 @@ enum Attribute: string
     case STEP = 'step';
 
     /**
+     * `target` — Specifies the browsing context for hyperlink navigation or form submission.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/target
+     */
+    case TARGET = 'target';
+
+    /**
      * `type` — Defines the type of the element.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/type

--- a/src/Values/Target.php
+++ b/src/Values/Target.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents target values for the HTML `target` attribute.
+ *
+ * Defines supported browsing context tokens as enum cases for use with elements that navigate or open linked resources.
+ *
+ * Key features.
+ * - Designed for use in anchor, area, base, form, and link elements that support the `target` attribute.
+ * - Enum values map to browsing context names as `string` values.
+ * - Suitable for rendering HTML attributes in view helpers and components.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/target
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Target: string
+{
+    /**
+     * `_blank` - Load the resource into a new, unnamed browsing context (typically a new tab or window).
+     *
+     * For security reasons, links with `target="_blank"` should use `rel="noopener noreferrer"` to prevent tabnabbing
+     * attacks.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/target#_blank
+     */
+    case BLANK = '_blank';
+
+    /**
+     * `_parent` - Load the resource into the parent browsing context of the current document.
+     *
+     * If there is no parent context, behaves the same as `_self`.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/target#_parent
+     */
+    case PARENT = '_parent';
+
+    /**
+     * `_self` - Load the resource into the same browsing context as the current document.
+     *
+     * This is the default behavior if no target is specified.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/target#_self
+     */
+    case SELF = '_self';
+
+    /**
+     * `_top` - Load the resource into the top-level browsing context (the full, original window).
+     *
+     * Useful for breaking out of nested framesets. If there is no parent context, behaves the same as `_self`.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/target#_top
+     */
+    case TOP = '_top';
+}

--- a/tests/HasTargetTest.php
+++ b/tests/HasTargetTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasTarget;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\TargetProvider;
+use UIAwesome\Html\Attribute\Values\{Attribute, Target};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasTarget} trait managing the `target` HTML attribute.
+ *
+ * Verifies rendered output, immutability, attribute override, and validation behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `target` attribute is not provided.
+ * - Sets the `target` HTML attribute and renders the expected output.
+ * - Throws an exception when the `target` attribute value is invalid.
+ *
+ * {@see TargetProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasTargetTest extends TestCase
+{
+    public function testReturnEmptyWhenTargetAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasTarget;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingTargetAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasTarget;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->target(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(TargetProvider::class, 'values')]
+    public function testSetTargetAttributeValue(
+        string|UnitEnum|null $target,
+        array $attributes,
+        string|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasTarget;
+        };
+
+        $instance = $instance->attributes($attributes)->target($target);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::TARGET, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testThrowExceptionWhenSettingInvalidTargetValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasTarget;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-target',
+                Attribute::TARGET->value,
+                implode('\', \'', Enum::normalizeArray(Target::cases())),
+            ),
+        );
+
+        $instance->target('invalid-target');
+    }
+}

--- a/tests/Support/Provider/TargetProvider.php
+++ b/tests/Support/Provider/TargetProvider.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use PHPForge\Support\EnumDataProvider;
+use UIAwesome\Html\Attribute\Values\{Attribute, Target};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasTargetTest} test cases.
+ *
+ * Provides representative input/output pairs for the `target` attribute.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TargetProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataProvider::attributeCases(Target::class, Attribute::TARGET);
+
+        $staticCase = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                '_blank',
+                ['target' => '_self'],
+                '_blank',
+                ' target="_blank"',
+                "Should return new 'target' after replacing the existing 'target' attribute.",
+            ],
+            'string _self' => [
+                '_self',
+                [],
+                '_self',
+                ' target="_self"',
+                'Should return the attribute value after setting it to _self.',
+            ],
+            'string _blank' => [
+                '_blank',
+                [],
+                '_blank',
+                ' target="_blank"',
+                'Should return the attribute value after setting it to _blank.',
+            ],
+            'string _parent' => [
+                '_parent',
+                [],
+                '_parent',
+                ' target="_parent"',
+                'Should return the attribute value after setting it to _parent.',
+            ],
+            'string _top' => [
+                '_top',
+                [],
+                '_top',
+                ' target="_top"',
+                'Should return the attribute value after setting it to _top.',
+            ],
+            'unset with null' => [
+                null,
+                ['target' => '_blank'],
+                '',
+                '',
+                "Should unset the 'target' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing HTML target attributes with built-in validation for common values (_blank, _parent, _self, _top)
  * Provides immutable API for setting and unsetting target attributes on HTML elements

* **Tests**
  * Added comprehensive test suite validating target attribute behavior and validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->