### PR TITLE
feat(attribute): Add `HasAs` trait and `as()` method to manage `as` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Enh #39: Add `HasSrc` trait and `src()` method to manage `src` attribute for HTML elements (@terabytesoftw)
 - Bug #40: Enhance documentation for HTML attributes (@terabytesoftw)
 - Enh #41: Add `HasTarget` trait and `target()` method to manage `target` attribute for HTML elements (@terabytesoftw)
+- Enh #42: Add `HasAs` trait and `as()` method to manage `as` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasAs.php
+++ b/src/HasAs.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\{AsValue, Attribute};
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `as` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `as` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `as` attribute and value validation.
+ *
+ * Key features.
+ * - Designed for use in link elements with `rel="preload"` or `rel="modulepreload"`.
+ * - Handles the HTML `as` attribute.
+ * - Immutable method for setting or overriding the `as` attribute.
+ * - Supports string, UnitEnum, and `null` for flexible assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#as
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasAs
+{
+    /**
+     * Sets the HTML `as` attribute for the element.
+     *
+     * Creates a new instance with the specified content type value.
+     *
+     * Specifies the type of content being loaded by the link element. This is necessary for request matching,
+     * application of correct content security policy, and setting of correct `Accept` request header.
+     *
+     * Furthermore, `rel="preload"` uses this as a signal for request prioritization.
+     *
+     * @param string|UnitEnum|null $value Content type value to set for the element. Use valid tokens like `audio`,
+     * `document`, `embed`, `fetch`, `font`, `image`, `object`, `script`, `style`, `track`, `video`, `worker`. Can be
+     * `null` to unset the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `as` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->as('font');
+     * $element->as(AsValue::FONT);
+     * $element->as(null);
+     * ```
+     */
+    public function as(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, AsValue::cases(), Attribute::AS);
+
+        return $this->addAttribute(Attribute::AS, $value);
+    }
+}

--- a/src/Values/AsValue.php
+++ b/src/Values/AsValue.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents values for the HTML `as` attribute used with `rel="preload"` and `rel="modulepreload"`.
+ *
+ * Defines the supported `as` tokens as enum cases. The `as` attribute specifies the type of content being loaded, which
+ * is necessary for request matching, application of correct content security policy, and setting of correct `Accept`
+ * request header.
+ *
+ * Key features.
+ * - Enum values map to content type tokens as `string` values.
+ * - Helps with request prioritization and CSP.
+ * - Used with preload and modulepreload link types.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#as
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum AsValue: string
+{
+    /**
+     * `audio` — Applies to `<audio>` elements.
+     */
+    case AUDIO = 'audio';
+
+    /**
+     * `document` — Applies to `<iframe>` and `<frame>` elements.
+     */
+    case DOCUMENT = 'document';
+
+    /**
+     * `embed` — Applies to `<embed>` elements.
+     */
+    case EMBED = 'embed';
+
+    /**
+     * `fetch` — Applies to fetch, XHR requests.
+     *
+     * Note: This value also requires the `crossorigin` attribute for CORS-enabled fetches.
+     */
+    case FETCH = 'fetch';
+
+    /**
+     * `font` — Applies to CSS @font-face.
+     *
+     * Note: This value also requires the `crossorigin` attribute for CORS-enabled fetches.
+     */
+    case FONT = 'font';
+
+    /**
+     * `image` — Applies to `<img>` and `<picture>` elements with srcset or imageset attributes,
+     * SVG `<image>` elements, CSS `*-image` rules.
+     */
+    case IMAGE = 'image';
+
+    /**
+     * `object` — Applies to `<object>` elements.
+     */
+    case OBJECT = 'object';
+
+    /**
+     * `script` — Applies to `<script>` elements, Worker `importScripts`.
+     */
+    case SCRIPT = 'script';
+
+    /**
+     * `style` — Applies to `<link rel=stylesheet>` elements, CSS `@import`.
+     */
+    case STYLE = 'style';
+
+    /**
+     * `track` — Applies to `<track>` elements.
+     */
+    case TRACK = 'track';
+
+    /**
+     * `video` — Applies to `<video>` elements.
+     */
+    case VIDEO = 'video';
+
+    /**
+     * `worker` — Applies to Worker, SharedWorker.
+     */
+    case WORKER = 'worker';
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -30,6 +30,13 @@ enum Attribute: string
     case ACCEPT = 'accept';
 
     /**
+     * `as` — Specifies the type of content being loaded by the link element.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#as
+     */
+    case AS = 'as';
+
+    /**
      * `autocomplete` — Indicates whether controls can have their values automatically completed.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete

--- a/tests/HasAsTest.php
+++ b/tests/HasAsTest.php
@@ -103,7 +103,7 @@ final class HasAsTest extends TestCase
             Message::VALUE_NOT_IN_LIST->getMessage(
                 'invalid-value',
                 Attribute::AS->value,
-                implode('", "', Enum::normalizeArray(AsValue::cases())),
+                implode("', '", Enum::normalizeArray(AsValue::cases())),
             ),
         );
 

--- a/tests/HasAsTest.php
+++ b/tests/HasAsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasAs;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\AsProvider;
+use UIAwesome\Html\Attribute\Values\{AsValue, Attribute};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasAs} trait managing the `as` HTML attribute.
+ *
+ * Verifies rendered output, immutability, attribute override, and validation behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `as` attribute is not provided.
+ * - Sets the `as` HTML attribute and renders the expected output.
+ * - Throws an exception when the `as` attribute value is invalid.
+ *
+ * {@see AsProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasAsTest extends TestCase
+{
+    public function testReturnEmptyWhenAsAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAs;
+            use HasAttributes;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingAsAttribute(): void
+    {
+        $instance = new class {
+            use HasAs;
+            use HasAttributes;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->as(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(AsProvider::class, 'values')]
+    public function testSetAsAttributeValue(
+        string|UnitEnum|null $as,
+        array $attributes,
+        string|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAs;
+            use HasAttributes;
+        };
+
+        $instance = $instance->attributes($attributes)->as($as);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::AS, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingAsValue(): void
+    {
+        $instance = new class {
+            use HasAs;
+            use HasAttributes;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                Attribute::AS->value,
+                implode('", "', Enum::normalizeArray(AsValue::cases())),
+            ),
+        );
+
+        $instance->as('invalid-value');
+    }
+}

--- a/tests/Support/Provider/AsProvider.php
+++ b/tests/Support/Provider/AsProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use PHPForge\Support\EnumDataProvider;
+use UIAwesome\Html\Attribute\Values\{AsValue, Attribute};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasAsTest} test cases.
+ *
+ * Provides representative input/output pairs for the `as` attribute.
+ *
+ * @copyright Copyright (C) 2025 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class AsProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataProvider::attributeCases(AsValue::class, Attribute::AS);
+
+        $staticCase = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'font',
+                ['as' => 'image'],
+                'font',
+                ' as="font"',
+                "Should return new 'as' after replacing the existing 'as' attribute.",
+            ],
+            'string' => [
+                'script',
+                [],
+                'script',
+                ' as="script"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['as' => 'style'],
+                '',
+                '',
+                "Should unset the 'as' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the HTML `as` attribute (audio, document, embed, fetch, font, image, object, script, style, track, video, worker) so preload-type can be specified.

* **Behavior**
  * Setting `as` is immutable, accepts string/enum/null to set or unset, and validates allowed tokens (throws on invalid values).

* **Tests**
  * Added unit tests covering default state, immutability, setting/unsetting, rendering, and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->