### PR TITLE
feat(attribute): Add `HasDisabled` trait and `disabled()` method to manage `disabled` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Enh #41: Add `HasTarget` trait and `target()` method to manage `target` attribute for HTML elements (@terabytesoftw)
 - Enh #42: Add `HasAs` trait and `as()` method to manage `as` attribute for HTML elements (@terabytesoftw)
 - Bug #43: Update copyright year to `2026` in multiple files (@terabytesoftw)
+- Enh #44: Add `HasDisabled` trait and `disabled()` method to manage `disabled` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasDisabled.php
+++ b/src/HasDisabled.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use UIAwesome\Html\Attribute\Values\Attribute;
+
+/**
+ * Trait for managing the HTML `disabled` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `disabled` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `disabled` attribute.
+ *
+ * Key features.
+ * - Designed for use in link elements with `rel="stylesheet"`.
+ * - Handles the HTML `disabled` attribute.
+ * - Immutable method for setting or overriding the `disabled` attribute.
+ * - Supports bool and `null` for flexible assignment.
+ *
+ * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#disabled
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasDisabled
+{
+    /**
+     * Sets the HTML `disabled` attribute for the element.
+     *
+     * Creates a new instance with the specified disabled state.
+     *
+     * Indicates whether the described stylesheet should be loaded and applied to the document. If `disabled` is
+     * specified when the HTML is loaded, the stylesheet will not be loaded during page load. Instead, the stylesheet
+     * will be loaded on-demand, if and when the `disabled` attribute is changed to `false` or removed.
+     *
+     * @param bool|null $value Disabled state to set for the element. Use `true` to disable, `false` to enable,
+     * or `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `disabled` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->disabled(true);
+     * $element->disabled(false);
+     * $element->disabled(null);
+     * ```
+     */
+    public function disabled(bool|null $value): static
+    {
+        return $this->addAttribute(Attribute::DISABLED, $value);
+    }
+}

--- a/tests/HasDisabledTest.php
+++ b/tests/HasDisabledTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasDisabled;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\DisabledProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasDisabled} trait managing the `disabled` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `disabled` attribute is not provided.
+ * - Sets the `disabled` HTML attribute and renders the expected output.
+ *
+ * {@see DisabledProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasDisabledTest extends TestCase
+{
+    public function testReturnEmptyWhenDisabledAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasDisabled;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingDisabledAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasDisabled;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->disabled(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(DisabledProvider::class, 'values')]
+    public function testSetDisabledAttributeValue(
+        bool|null $disabled,
+        array $attributes,
+        bool|null $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasDisabled;
+        };
+
+        $instance = $instance->attributes($attributes)->disabled($disabled);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::DISABLED, null),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/DisabledProvider.php
+++ b/tests/Support/Provider/DisabledProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use UIAwesome\Html\Attribute\Values\Attribute;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasDisabledTest} test cases.
+ *
+ * Provides representative input/output pairs for the `disabled` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class DisabledProvider
+{
+    /**
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|null, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'null' => [
+                null,
+                [],
+                null,
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'true' => [
+                true,
+                [],
+                true,
+                ' disabled',
+                'Should return the attribute value after setting it to true.',
+            ],
+            'false' => [
+                false,
+                [],
+                false,
+                '',
+                'Should return empty string when setting false (boolean attribute).',
+            ],
+            'replace existing' => [
+                true,
+                ['disabled' => false],
+                true,
+                ' disabled',
+                "Should return new 'disabled' after replacing the existing 'disabled' attribute.",
+            ],
+            'unset with null' => [
+                null,
+                ['disabled' => true],
+                null,
+                '',
+                "Should unset the 'disabled' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for managing the disabled attribute on HTML elements through an immutable API.

* **Tests**
  * Added comprehensive test suite for disabled attribute functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->