### PR TITLE
feat(attribute): Add `HasHrefLang` trait and `hreflang()` method to manage `hreflang` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Enh #42: Add `HasAs` trait and `as()` method to manage `as` attribute for HTML elements (@terabytesoftw)
 - Bug #43: Update copyright year to `2026` in multiple files (@terabytesoftw)
 - Enh #44: Add `HasDisabled` trait and `disabled()` method to manage `disabled` attribute for HTML elements (@terabytesoftw)
+- Enh #45: Add `HasHrefLang` trait and `hreflang()` method to manage `hreflang` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Enh #42: Add `HasAs` trait and `as()` method to manage `as` attribute for HTML elements (@terabytesoftw)
 - Bug #43: Update copyright year to `2026` in multiple files (@terabytesoftw)
 - Enh #44: Add `HasDisabled` trait and `disabled()` method to manage `disabled` attribute for HTML elements (@terabytesoftw)
-- Enh #45: Add `HasHrefLang` trait and `hreflang()` method to manage `hreflang` attribute for HTML elements (@terabytesoftw)
+- Enh #45: Add `HasHreflang` trait and `hreflang()` method to manage `hreflang` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasHreflang.php
+++ b/src/HasHreflang.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `hreflang` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `hreflang` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `hreflang` attribute.
+ *
+ * Key features.
+ * - Designed for use in link and anchor elements.
+ * - Handles the HTML `hreflang` attribute.
+ * - Immutable method for setting or overriding the `hreflang` attribute.
+ * - Supports string, Stringable, UnitEnum, and `null` for flexible assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#hreflang
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasHreflang
+{
+    /**
+     * Sets the HTML `hreflang` attribute for the element.
+     *
+     * Creates a new instance with the specified language code value.
+     *
+     * Indicates the language of the linked resource. It is purely advisory. Values should be valid BCP 47 language
+     * tags. Use this attribute only if the `href` attribute is present.
+     *
+     * @param string|Stringable|UnitEnum|null $value Language code value to set for the element. Use valid BCP 47
+     * language tags (for example, `en`, `es`, `fr`). Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `hreflang` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->hreflang('en');
+     * $element->hreflang('es');
+     * $element->hreflang(null);
+     * ```
+     */
+    public function hreflang(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::HREFLANG, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -114,6 +114,13 @@ enum Attribute: string
     case FORM = 'form';
 
     /**
+     * `hreflang` — Indicates the language of the linked resource.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#hreflang
+     */
+    case HREFLANG = 'hreflang';
+
+    /**
      * `integrity` — Contains inline metadata that a user agent can use to verify that a fetched resource has been
      * delivered without unexpected manipulation (Subresource Integrity).
      *

--- a/tests/HasHreflangTest.php
+++ b/tests/HasHreflangTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasHreflang;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\HreflangProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasHreflang} trait managing the `hreflang` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `hreflang` attribute is not provided.
+ * - Sets the `hreflang` HTML attribute and renders the expected output.
+ *
+ * {@see HreflangProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasHreflangTest extends TestCase
+{
+    public function testReturnEmptyWhenHreflangAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasHreflang;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingHreflangAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasHreflang;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->hreflang(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(HreflangProvider::class, 'values')]
+    public function testSetHreflangAttributeValue(
+        string|Stringable|UnitEnum|null $hreflang,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasHreflang;
+        };
+
+        $instance = $instance->attributes($attributes)->hreflang($hreflang);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::HREFLANG, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/HreflangProvider.php
+++ b/tests/Support/Provider/HreflangProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasHreflangTest} test cases.
+ *
+ * Provides representative input/output pairs for the `hreflang` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class HreflangProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|\UnitEnum|null, mixed[], string|\UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'es',
+                ['hreflang' => 'en'],
+                'es',
+                ' hreflang="es"',
+                "Should return new 'hreflang' after replacing the existing 'hreflang' attribute.",
+            ],
+            'string en' => [
+                'en',
+                [],
+                'en',
+                ' hreflang="en"',
+                'Should return the attribute value after setting it to en.',
+            ],
+            'string es' => [
+                'es',
+                [],
+                'es',
+                ' hreflang="es"',
+                'Should return the attribute value after setting it to es.',
+            ],
+            'string fr' => [
+                'fr',
+                [],
+                'fr',
+                ' hreflang="fr"',
+                'Should return the attribute value after setting it to fr.',
+            ],
+            'unset with null' => [
+                null,
+                ['hreflang' => 'en'],
+                '',
+                '',
+                "Should unset the 'hreflang' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hreflang attribute support for HTML link-like elements, enabling specification of language variants and alternate content versions to improve SEO and internationalization; supports setting and clearing hreflang values.

* **Tests**
  * Added comprehensive, data-driven tests covering various hreflang inputs, rendering outcomes, and edge cases to ensure correct behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->