### PR TITLE
feat(attribute): Add `HasImagesizes` trait and `imagesizes()` method to manage `imagesizes` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bug #43: Update copyright year to `2026` in multiple files (@terabytesoftw)
 - Enh #44: Add `HasDisabled` trait and `disabled()` method to manage `disabled` attribute for HTML elements (@terabytesoftw)
 - Enh #45: Add `HasHreflang` trait and `hreflang()` method to manage `hreflang` attribute for HTML elements (@terabytesoftw)
+- Enh #46: Add `HasImagesizes` trait and `imagesizes()` method to manage `imagesizes` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasImagesizes.php
+++ b/src/HasImagesizes.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `imagesizes` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `imagesizes` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `imagesizes` attribute.
+ *
+ * Key features.
+ * - Designed for use in link elements with `rel="preload"` and `as="image"`.
+ * - Handles the HTML `imagesizes` attribute.
+ * - Immutable method for setting or overriding the `imagesizes` attribute.
+ * - Supports string, Stringable, UnitEnum, and `null` for flexible assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#imagesizes
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasImagesizes
+{
+    /**
+     * Sets the HTML `imagesizes` attribute for the element.
+     *
+     * Creates a new instance with the specified image sizes value.
+     *
+     * For `rel="preload"` and `as="image"` only, the `imagesizes` attribute has similar syntax and semantics as the
+     * `sizes` attribute that indicates to preload the appropriate resource used by an `img` element with corresponding
+     * values for its `srcset` and `sizes` attributes.
+     *
+     * @param string|Stringable|UnitEnum|null $value Image sizes value to set for the element. Use valid sizes syntax
+     * (for example, `100vw`, `(max-width: 600px) 100vw, 50vw`). Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `imagesizes` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->imagesizes('100vw');
+     * $element->imagesizes('(max-width: 600px) 100vw, 50vw');
+     * $element->imagesizes(null);
+     * ```
+     */
+    public function imagesizes(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::IMAGESIZES, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -121,6 +121,13 @@ enum Attribute: string
     case HREFLANG = 'hreflang';
 
     /**
+     * `imagesizes` — Specifies the image sizes for preload.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#imagesizes
+     */
+    case IMAGESIZES = 'imagesizes';
+
+    /**
      * `integrity` — Contains inline metadata that a user agent can use to verify that a fetched resource has been
      * delivered without unexpected manipulation (Subresource Integrity).
      *

--- a/tests/HasImagesizesTest.php
+++ b/tests/HasImagesizesTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasImagesizes;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\ImagesizesProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasImagesizes} trait managing the `imagesizes` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `imagesizes` attribute is not provided.
+ * - Sets the `imagesizes` HTML attribute and renders the expected output.
+ *
+ * {@see ImagesizesProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasImagesizesTest extends TestCase
+{
+    public function testReturnEmptyWhenImagesizesAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasImagesizes;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingImagesizesAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasImagesizes;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->imagesizes(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(ImagesizesProvider::class, 'values')]
+    public function testSetImagesizesAttributeValue(
+        string|Stringable|UnitEnum|null $imagesizes,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasImagesizes;
+        };
+
+        $instance = $instance->attributes($attributes)->imagesizes($imagesizes);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::IMAGESIZES, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/ImagesizesProvider.php
+++ b/tests/Support/Provider/ImagesizesProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasImagesizesTest} test cases.
+ *
+ * Provides representative input/output pairs for the `imagesizes` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ImagesizesProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|\UnitEnum|null, mixed[], string|\UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                '50vw',
+                ['imagesizes' => '100vw'],
+                '50vw',
+                ' imagesizes="50vw"',
+                "Should return new 'imagesizes' after replacing the existing 'imagesizes' attribute.",
+            ],
+            'string 100vw' => [
+                '100vw',
+                [],
+                '100vw',
+                ' imagesizes="100vw"',
+                'Should return the attribute value after setting it to 100vw.',
+            ],
+            'string media query' => [
+                '(max-width: 600px) 100vw, 50vw',
+                [],
+                '(max-width: 600px) 100vw, 50vw',
+                ' imagesizes="(max-width: 600px) 100vw, 50vw"',
+                'Should return the attribute value after setting it with media query.',
+            ],
+            'unset with null' => [
+                null,
+                ['imagesizes' => '100vw'],
+                '',
+                '',
+                "Should unset the 'imagesizes' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the imagesizes HTML attribute, enabling responsive image size specifications for preload link elements.

* **Tests**
  * Added comprehensive test coverage for the new imagesizes attribute functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->