### PR TITLE
feat(attribute): Add `HasImagesrcset` trait and `imagesrcset()` method to manage `imagesrcset` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Enh #44: Add `HasDisabled` trait and `disabled()` method to manage `disabled` attribute for HTML elements (@terabytesoftw)
 - Enh #45: Add `HasHreflang` trait and `hreflang()` method to manage `hreflang` attribute for HTML elements (@terabytesoftw)
 - Enh #46: Add `HasImagesizes` trait and `imagesizes()` method to manage `imagesizes` attribute for HTML elements (@terabytesoftw)
+- Enh #47: Add `HasImagesrcset` trait and `imagesrcset()` method to manage `imagesrcset` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasImagesrcset.php
+++ b/src/HasImagesrcset.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `imagesrcset` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `imagesrcset` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `imagesrcset` attribute.
+ *
+ * Key features.
+ * - Designed for use in link elements with `rel="preload"` and `as="image"`.
+ * - Handles the HTML `imagesrcset` attribute.
+ * - Immutable method for setting or overriding the `imagesrcset` attribute.
+ * - Supports string, Stringable, UnitEnum, and `null` for flexible assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#imagesrcset
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasImagesrcset
+{
+    /**
+     * Sets the HTML `imagesrcset` attribute for the element.
+     *
+     * Creates a new instance with the specified image srcset value.
+     *
+     * For `rel="preload"` and `as="image"` only, the `imagesrcset` attribute has similar syntax and semantics as the
+     * `srcset` attribute that indicates to preload the appropriate resource used by an `img` element with corresponding
+     * values for its `srcset` and `sizes` attributes.
+     *
+     * @param string|Stringable|UnitEnum|null $value Image srcset value to set for the element. Use valid srcset syntax
+     * (for example, `image-400.jpg 400w, image-800.jpg 800w`). Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `imagesrcset` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->imagesrcset('image-400.jpg 400w, image-800.jpg 800w');
+     * $element->imagesrcset(null);
+     * ```
+     */
+    public function imagesrcset(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::IMAGESRCSET, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -128,6 +128,13 @@ enum Attribute: string
     case IMAGESIZES = 'imagesizes';
 
     /**
+     * `imagesrcset` — Specifies the image srcset for preload.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#imagesrcset
+     */
+    case IMAGESRCSET = 'imagesrcset';
+
+    /**
      * `integrity` — Contains inline metadata that a user agent can use to verify that a fetched resource has been
      * delivered without unexpected manipulation (Subresource Integrity).
      *

--- a/tests/HasImagesrcsetTest.php
+++ b/tests/HasImagesrcsetTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasImagesrcset;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\ImagesrcsetProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasImagesrcset} trait managing the `imagesrcset` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `imagesrcset` attribute is not provided.
+ * - Sets the `imagesrcset` HTML attribute and renders the expected output.
+ *
+ * {@see ImagesrcsetProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasImagesrcsetTest extends TestCase
+{
+    public function testReturnEmptyWhenImagesrcsetAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasImagesrcset;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingImagesrcsetAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasImagesrcset;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->imagesrcset(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(ImagesrcsetProvider::class, 'values')]
+    public function testSetImagesrcsetAttributeValue(
+        string|Stringable|UnitEnum|null $imagesrcset,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasImagesrcset;
+        };
+
+        $instance = $instance->attributes($attributes)->imagesrcset($imagesrcset);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::IMAGESRCSET, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/ImagesrcsetProvider.php
+++ b/tests/Support/Provider/ImagesrcsetProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasImagesrcsetTest} test cases.
+ *
+ * Provides representative input/output pairs for the `imagesrcset` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ImagesrcsetProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|\UnitEnum|null, mixed[], string|\UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'image-200.jpg 200w',
+                ['imagesrcset' => 'image-400.jpg 400w'],
+                'image-200.jpg 200w',
+                ' imagesrcset="image-200.jpg 200w"',
+                "Should return new 'imagesrcset' after replacing the existing 'imagesrcset' attribute.",
+            ],
+            'string single' => [
+                'image-400.jpg 400w',
+                [],
+                'image-400.jpg 400w',
+                ' imagesrcset="image-400.jpg 400w"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string multiple' => [
+                'image-400.jpg 400w, image-800.jpg 800w, image-1200.jpg 1200w',
+                [],
+                'image-400.jpg 400w, image-800.jpg 800w, image-1200.jpg 1200w',
+                ' imagesrcset="image-400.jpg 400w, image-800.jpg 800w, image-1200.jpg 1200w"',
+                'Should return the attribute value after setting multiple sources.',
+            ],
+            'unset with null' => [
+                null,
+                ['imagesrcset' => 'image-400.jpg 400w'],
+                '',
+                '',
+                "Should unset the 'imagesrcset' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `imagesrcset` HTML attribute on elements, enabling responsive image source configuration for preload links. The attribute accepts multiple value types including strings, Stringable objects, and enums while maintaining immutability.

* **Tests**
  * Added comprehensive test coverage validating attribute storage, rendering behavior, and immutable instance creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->