### PR TITLE
feat(attribute): Add `HasSizes` trait and `sizes()` method to manage `sizes` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Enh #45: Add `HasHreflang` trait and `hreflang()` method to manage `hreflang` attribute for HTML elements (@terabytesoftw)
 - Enh #46: Add `HasImagesizes` trait and `imagesizes()` method to manage `imagesizes` attribute for HTML elements (@terabytesoftw)
 - Enh #47: Add `HasImagesrcset` trait and `imagesrcset()` method to manage `imagesrcset` attribute for HTML elements (@terabytesoftw)
+- Enh #48: Add `HasSizes` trait and `sizes()` method to manage `sizes` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasSizes.php
+++ b/src/HasSizes.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `sizes` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `sizes` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `sizes` attribute.
+ *
+ * Key features.
+ * - Designed for use in link elements with `rel="icon"` or similar icon types.
+ * - Handles the HTML `sizes` attribute.
+ * - Immutable method for setting or overriding the `sizes` attribute.
+ * - Supports string, Stringable, UnitEnum, and `null` for flexible assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#sizes
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasSizes
+{
+    /**
+     * Sets the HTML `sizes` attribute for the element.
+     *
+     * Creates a new instance with the specified sizes value.
+     *
+     * Defines the sizes of the icons for visual media contained in the resource. It must be present only if the `rel`
+     * contains a value of `icon` or a non-standard type such as Apple's `apple-touch-icon`. It may have the following
+     * values: `any`, meaning that the icon can be scaled to any size as it is in a vector format, or a white-space
+     * separated list of sizes, each in the format `<width>x<height>`.
+     *
+     * @param string|Stringable|UnitEnum|null $value Sizes value to set for the element. Use `any` for vector formats,
+     * or size list like `16x16 32x32 48x48`. Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `sizes` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->sizes('any');
+     * $element->sizes('16x16 32x32');
+     * $element->sizes(null);
+     * ```
+     */
+    public function sizes(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::SIZES, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -234,6 +234,13 @@ enum Attribute: string
     case SIZE = 'size';
 
     /**
+     * `sizes` — Defines the sizes of icons for visual media.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#sizes
+     */
+    case SIZES = 'sizes';
+
+    /**
      * `src` — Specifies the URL of the resource.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/src

--- a/tests/HasSizesTest.php
+++ b/tests/HasSizesTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasSizes;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\SizesProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasSizes} trait managing the `sizes` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `sizes` attribute is not provided.
+ * - Sets the `sizes` HTML attribute and renders the expected output.
+ *
+ * {@see SizesProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasSizesTest extends TestCase
+{
+    public function testReturnEmptyWhenSizesAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasSizes;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingSizesAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasSizes;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->sizes(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(SizesProvider::class, 'values')]
+    public function testSetSizesAttributeValue(
+        string|Stringable|UnitEnum|null $sizes,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasSizes;
+        };
+
+        $instance = $instance->attributes($attributes)->sizes($sizes);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::SIZES, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/SizesProvider.php
+++ b/tests/Support/Provider/SizesProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasSizesTest} test cases.
+ *
+ * Provides representative input/output pairs for the `sizes` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class SizesProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|\UnitEnum|null, mixed[], string|\UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                '32x32',
+                ['sizes' => '16x16'],
+                '32x32',
+                ' sizes="32x32"',
+                "Should return new 'sizes' after replacing the existing 'sizes' attribute.",
+            ],
+            'string any' => [
+                'any',
+                [],
+                'any',
+                ' sizes="any"',
+                'Should return the attribute value after setting it to any.',
+            ],
+            'string single size' => [
+                '16x16',
+                [],
+                '16x16',
+                ' sizes="16x16"',
+                'Should return the attribute value after setting it to single size.',
+            ],
+            'string multiple sizes' => [
+                '16x16 32x32 48x48',
+                [],
+                '16x16 32x32 48x48',
+                ' sizes="16x16 32x32 48x48"',
+                'Should return the attribute value after setting multiple sizes.',
+            ],
+            'unset with null' => [
+                null,
+                ['sizes' => '16x16'],
+                '',
+                '',
+                "Should unset the 'sizes' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new functionality to manage HTML sizes attributes.
  * Provides an immutable API that returns new instances when modified.
  * Supports string, Stringable, UnitEnum, and null values for flexible attribute management.
* **Tests**
  * Added comprehensive test coverage including immutability validation and various input scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->