### PR TITLE
feat(attribute): Add `HasCharset` trait and `charset()` method to manage `charset` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Enh #46: Add `HasImagesizes` trait and `imagesizes()` method to manage `imagesizes` attribute for HTML elements (@terabytesoftw)
 - Enh #47: Add `HasImagesrcset` trait and `imagesrcset()` method to manage `imagesrcset` attribute for HTML elements (@terabytesoftw)
 - Enh #48: Add `HasSizes` trait and `sizes()` method to manage `sizes` attribute for HTML elements (@terabytesoftw)
+- Enh #49: Add `HasCharset` trait and `charset()` method to manage `charset` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasCharset.php
+++ b/src/HasCharset.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\{Attribute, Charset};
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `charset` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `charset` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `charset` attribute and value validation.
+ *
+ * Key features.
+ * - Designed for use in meta elements.
+ * - Handles the HTML `charset` attribute.
+ * - Immutable method for setting or overriding the `charset` attribute.
+ * - Supports string, UnitEnum, and `null` for flexible charset assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta#charset
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasCharset
+{
+    /**
+     * Sets the HTML `charset` attribute for the element.
+     *
+     * Creates a new instance with the specified character encoding value.
+     *
+     * Declares the document's character encoding. If the attribute is present, its value must be an ASCII
+     * case-insensitive match for the string `"utf-8"`, because UTF-8 is the only valid encoding for HTML5 documents.
+     *
+     * `<meta>` elements which declare a character encoding must be located entirely within the first 1024 bytes of
+     * the document.
+     *
+     * @param string|UnitEnum|null $value Character encoding value to set for the element. Use `utf-8` (the only
+     * valid encoding for HTML5). Can be `null` to unset the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `charset` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->charset('utf-8');
+     * $element->charset(Charset::UTF_8);
+     * $element->charset(null);
+     * ```
+     */
+    public function charset(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, Charset::cases(), Attribute::CHARSET);
+
+        return $this->addAttribute(Attribute::CHARSET, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -58,6 +58,13 @@ enum Attribute: string
     case CAPTURE = 'capture';
 
     /**
+     * `charset` — Declares the document's character encoding.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta#charset
+     */
+    case CHARSET = 'charset';
+
+    /**
      * `content` — A value associated with a meta element.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/content

--- a/src/Values/Charset.php
+++ b/src/Values/Charset.php
@@ -132,6 +132,7 @@ enum Charset: string
      * `utf-32le` — Unicode UTF-32 Little Endian.
      */
     case UTF_32LE = 'utf-32le';
+
     /**
      * `utf-8` — Unicode UTF-8 encoding (the only valid encoding for HTML5 documents).
      */

--- a/src/Values/Charset.php
+++ b/src/Values/Charset.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents character encoding values for the HTML `charset` attribute.
+ *
+ * Defines commonly used character encoding tokens as enum cases. While HTML5 only officially supports UTF-8,
+ * this enum includes other common encodings for legacy and specialized use cases.
+ *
+ * Key features.
+ * - Enum values map to character encoding names as `string` values.
+ * - Includes UTF-8 (the HTML5 standard) and other common encodings.
+ * - Based on IANA registered character sets.
+ *
+ * @link https://www.iana.org/assignments/character-sets/character-sets.xhtml
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta#charset
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Charset: string
+{
+    /**
+     * `big5` — Traditional Chinese (Big5).
+     */
+    case BIG5 = 'big5';
+
+    /**
+     * `euc-jp` — Japanese (EUC-JP).
+     */
+    case EUC_JP = 'euc-jp';
+
+    /**
+     * `euc-kr` — Korean (EUC-KR).
+     */
+    case EUC_KR = 'euc-kr';
+
+    /**
+     * `gb2312` — Simplified Chinese (GB2312).
+     */
+    case GB2312 = 'gb2312';
+
+    /**
+     * `gbk` — Simplified Chinese (GBK/GBX).
+     */
+    case GBK = 'gbk';
+
+    /**
+     * `iso-2022-jp` — Japanese (ISO-2022-JP).
+     */
+    case ISO_2022_JP = 'iso-2022-jp';
+
+    /**
+     * `iso-8859-1` — Latin-1 (Western European).
+     */
+    case ISO_8859_1 = 'iso-8859-1';
+
+    /**
+     * `iso-8859-15` — Latin-9 (Western European with Euro sign).
+     */
+    case ISO_8859_15 = 'iso-8859-15';
+
+    /**
+     * `iso-8859-2` — Latin-2 (Central European).
+     */
+    case ISO_8859_2 = 'iso-8859-2';
+
+    /**
+     * `iso-8859-6` — Latin/Arabic.
+     */
+    case ISO_8859_6 = 'iso-8859-6';
+
+    /**
+     * `iso-8859-7` — Greek.
+     */
+    case ISO_8859_7 = 'iso-8859-7';
+
+    /**
+     * `iso-8859-8` — Latin/Hebrew.
+     */
+    case ISO_8859_8 = 'iso-8859-8';
+
+    /**
+     * `iso-8859-9` — Latin-5 (Turkish).
+     */
+    case ISO_8859_9 = 'iso-8859-9';
+
+    /**
+     * `koi8-r` — Russian (KOI8-R).
+     */
+    case KOI8_R = 'koi8-r';
+
+    /**
+     * `koi8-u` — Ukrainian (KOI8-U).
+     */
+    case KOI8_U = 'koi8-u';
+
+    /**
+     * `shift_jis` — Japanese (Shift JIS).
+     */
+    case SHIFT_JIS = 'shift_jis';
+
+    /**
+     * `utf-16` — Unicode UTF-16 encoding.
+     */
+    case UTF_16 = 'utf-16';
+
+    /**
+     * `utf-16be` — Unicode UTF-16 Big Endian.
+     */
+    case UTF_16BE = 'utf-16be';
+
+    /**
+     * `utf-16le` — Unicode UTF-16 Little Endian.
+     */
+    case UTF_16LE = 'utf-16le';
+
+    /**
+     * `utf-32` — Unicode UTF-32 encoding.
+     */
+    case UTF_32 = 'utf-32';
+
+    /**
+     * `utf-32be` — Unicode UTF-32 Big Endian.
+     */
+    case UTF_32BE = 'utf-32be';
+
+    /**
+     * `utf-32le` — Unicode UTF-32 Little Endian.
+     */
+    case UTF_32LE = 'utf-32le';
+    /**
+     * `utf-8` — Unicode UTF-8 encoding (the only valid encoding for HTML5 documents).
+     */
+    case UTF_8 = 'utf-8';
+
+    /**
+     * `windows-1251` — Windows Cyrillic.
+     */
+    case WINDOWS_1251 = 'windows-1251';
+
+    /**
+     * `windows-1252` — Windows Latin-1 (Western European).
+     */
+    case WINDOWS_1252 = 'windows-1252';
+
+    /**
+     * `windows-1253` — Windows Greek.
+     */
+    case WINDOWS_1253 = 'windows-1253';
+
+    /**
+     * `windows-1254` — Windows Turkish.
+     */
+    case WINDOWS_1254 = 'windows-1254';
+
+    /**
+     * `windows-1255` — Windows Hebrew.
+     */
+    case WINDOWS_1255 = 'windows-1255';
+
+    /**
+     * `windows-1256` — Windows Arabic.
+     */
+    case WINDOWS_1256 = 'windows-1256';
+}

--- a/tests/HasCharsetTest.php
+++ b/tests/HasCharsetTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Attribute\Tests;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Attribute\HasCharset;
 use UIAwesome\Html\Attribute\Tests\Support\Provider\CharsetProvider;
-use UIAwesome\Html\Attribute\Values\Attribute;
-use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Attribute\Values\{Attribute, Charset};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Helper\{Attributes, Enum};
 use UIAwesome\Html\Mixin\HasAttributes;
 use UnitEnum;
 
@@ -22,6 +24,7 @@ use UnitEnum;
  * - Ensures fluent setters return new instances (immutability).
  * - Ensures no attributes are set when the `charset` attribute is not provided.
  * - Sets the `charset` HTML attribute and renders the expected output.
+ * - Throws an exception when the `charset` attribute value is invalid.
  *
  * {@see CharsetProvider} for test case data providers.
  *
@@ -86,5 +89,24 @@ final class HasCharsetTest extends TestCase
             Attributes::render($instance->getAttributes()),
             $message,
         );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingCharsetValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasCharset;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                Attribute::CHARSET->value,
+                implode("', '", Enum::normalizeArray(Charset::cases())),
+            ),
+        );
+
+        $instance->charset('invalid-value');
     }
 }

--- a/tests/HasCharsetTest.php
+++ b/tests/HasCharsetTest.php
@@ -10,8 +10,8 @@ use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Attribute\HasCharset;
 use UIAwesome\Html\Attribute\Tests\Support\Provider\CharsetProvider;
 use UIAwesome\Html\Attribute\Values\{Attribute, Charset};
-use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Mixin\HasAttributes;
 use UnitEnum;
 

--- a/tests/HasCharsetTest.php
+++ b/tests/HasCharsetTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasCharset;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\CharsetProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasCharset} trait managing the `charset` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `charset` attribute is not provided.
+ * - Sets the `charset` HTML attribute and renders the expected output.
+ *
+ * {@see CharsetProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasCharsetTest extends TestCase
+{
+    public function testReturnEmptyWhenCharsetAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasCharset;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingCharsetAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasCharset;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->charset(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(CharsetProvider::class, 'values')]
+    public function testSetCharsetAttributeValue(
+        string|UnitEnum|null $charset,
+        array $attributes,
+        string|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasCharset;
+        };
+
+        $instance = $instance->attributes($attributes)->charset($charset);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::CHARSET, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/CharsetProvider.php
+++ b/tests/Support/Provider/CharsetProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use PHPForge\Support\EnumDataProvider;
+use UIAwesome\Html\Attribute\Values\{Attribute, Charset};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasCharsetTest} test cases.
+ *
+ * Provides representative input/output pairs for the `charset` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class CharsetProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataProvider::attributeCases(Charset::class, Attribute::CHARSET);
+
+        $staticCase = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'utf-8',
+                ['charset' => 'iso-8859-1'],
+                'utf-8',
+                ' charset="utf-8"',
+                "Should return new 'charset' after replacing the existing 'charset' attribute.",
+            ],
+            'string' => [
+                'utf-8',
+                [],
+                'utf-8',
+                ' charset="utf-8"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['charset' => 'utf-8'],
+                '',
+                '',
+                "Should unset the 'charset' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added charset attribute support for HTML elements with extensive encoding options (UTF‑8, ISO‑8859 variants, Windows code pages, Asian encodings, etc.).
* **Tests**
  * Added unit tests and a data provider to validate setting, rendering, immutability, and invalid-value handling for charset.
* **Documentation**
  * Added changelog entry describing the new charset capability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->