### PR TITLE
feat(attribute): Add `HasContent` trait and `content()` method to manage `content` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Enh #47: Add `HasImagesrcset` trait and `imagesrcset()` method to manage `imagesrcset` attribute for HTML elements (@terabytesoftw)
 - Enh #48: Add `HasSizes` trait and `sizes()` method to manage `sizes` attribute for HTML elements (@terabytesoftw)
 - Enh #49: Add `HasCharset` trait and `charset()` method to manage `charset` attribute for HTML elements (@terabytesoftw)
+- Enh #50: Add `HasContent` trait and `content()` method to manage `content` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasContent.php
+++ b/src/HasContent.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `content` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `content` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `content` attribute.
+ *
+ * Key features.
+ * - Designed for use in meta elements.
+ * - Handles the HTML `content` attribute.
+ * - Immutable method for setting or overriding the `content` attribute.
+ * - Supports string, Stringable, UnitEnum, and `null` for flexible content assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/content
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasContent
+{
+    /**
+     * Sets the HTML `content` attribute for the element.
+     *
+     * Creates a new instance with the specified content value.
+     *
+     * Contains the value for the `http-equiv` or `name` attribute, depending on which is used. This attribute provides
+     * the actual metadata value associated with the metadata name or pragma directive.
+     *
+     * @param string|Stringable|UnitEnum|null $value Content value to set for the element. Use a string representing
+     * the metadata value. Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `content` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->content('width=device-width, initial-scale=1');
+     * $element->content('The HTML reference describes all elements...');
+     * $element->content(null);
+     * ```
+     */
+    public function content(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::CONTENT, $value);
+    }
+}

--- a/tests/HasContentTest.php
+++ b/tests/HasContentTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasContent;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\ContentProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasContent} trait managing the `content` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `content` attribute is not provided.
+ * - Sets the `content` HTML attribute and renders the expected output.
+ *
+ * {@see ContentProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasContentTest extends TestCase
+{
+    public function testReturnEmptyWhenContentAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasContent;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingContentAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasContent;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->content(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(ContentProvider::class, 'values')]
+    public function testSetContentAttributeValue(
+        string|Stringable|UnitEnum|null $content,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasContent;
+        };
+
+        $instance = $instance->attributes($attributes)->content($content);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::CONTENT, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/ContentProvider.php
+++ b/tests/Support/Provider/ContentProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasContentTest} test cases.
+ *
+ * Provides representative input/output pairs for the `content` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ContentProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'new-content',
+                ['content' => 'old-content'],
+                'new-content',
+                ' content="new-content"',
+                "Should return new 'content' after replacing the existing 'content' attribute.",
+            ],
+            'string simple' => [
+                'width=device-width, initial-scale=1',
+                [],
+                'width=device-width, initial-scale=1',
+                ' content="width=device-width, initial-scale=1"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string with special chars' => [
+                '3;url=https://example.com',
+                [],
+                '3;url=https://example.com',
+                ' content="3;url=https://example.com"',
+                'Should return the attribute value with special characters.',
+            ],
+            'unset with null' => [
+                null,
+                ['content' => 'some-content'],
+                '',
+                '',
+                "Should unset the 'content' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing HTML content attributes on elements through an immutable interface
  * Accepts multiple value types: strings, Stringable objects, enums, and null for unsetting
  * Follows the framework's immutable API pattern, returning new instances after modifications
  * Enhances flexibility for meta elements and content-driven HTML components

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->