### PR TITLE
feat(attribute): Add `HasHttpEquiv` trait and `httpEquiv()` method to manage `http-equiv` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Enh #48: Add `HasSizes` trait and `sizes()` method to manage `sizes` attribute for HTML elements (@terabytesoftw)
 - Enh #49: Add `HasCharset` trait and `charset()` method to manage `charset` attribute for HTML elements (@terabytesoftw)
 - Enh #50: Add `HasContent` trait and `content()` method to manage `content` attribute for HTML elements (@terabytesoftw)
+- Enh #51: Add `HasHttpEquiv` trait and `httpEquiv()` method to manage `http-equiv` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasHttpEquiv.php
+++ b/src/HasHttpEquiv.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\{Attribute, HttpEquiv};
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `http-equiv` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `http-equiv` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `http-equiv` attribute and value validation.
+ *
+ * Key features.
+ * - Designed for use in meta elements.
+ * - Handles the HTML `http-equiv` attribute.
+ * - Immutable method for setting or overriding the `http-equiv` attribute.
+ * - Supports string, UnitEnum, and `null` for flexible pragma directive assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/http-equiv
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasHttpEquiv
+{
+    /**
+     * Sets the HTML `http-equiv` attribute for the element.
+     *
+     * Creates a new instance with the specified pragma directive value.
+     *
+     * Defines a pragma directive, which are instructions for the browser for processing the document. The attribute's
+     * name is short for `http-equivalent` because the allowed values are names of equivalent HTTP headers.
+     *
+     * @param string|UnitEnum|null $value Pragma directive value to set for the element. Use valid tokens like
+     * `content-type`, `default-style`, `refresh`, `x-ua-compatible`, `content-security-policy`. Can be `null` to unset
+     * the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `http-equiv` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->httpEquiv('refresh');
+     * $element->httpEquiv(HttpEquiv::REFRESH);
+     * $element->httpEquiv(null);
+     * ```
+     */
+    public function httpEquiv(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, HttpEquiv::cases(), Attribute::HTTP_EQUIV);
+
+        return $this->addAttribute(Attribute::HTTP_EQUIV, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -128,6 +128,13 @@ enum Attribute: string
     case HREFLANG = 'hreflang';
 
     /**
+     * `http-equiv` — Defines a pragma directive for processing the document.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/http-equiv
+     */
+    case HTTP_EQUIV = 'http-equiv';
+
+    /**
      * `imagesizes` — Specifies the image sizes for preload.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#imagesizes

--- a/src/Values/HttpEquiv.php
+++ b/src/Values/HttpEquiv.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents values for the HTML `http-equiv` attribute.
+ *
+ * Defines the supported `http-equiv` tokens as enum cases. The `http-equiv` attribute defines a pragma directive, which
+ * are instructions for the browser for processing the document.
+ *
+ * Key features.
+ * - Enum values map to pragma directive tokens as `string` values.
+ * - Used with meta elements to simulate HTTP headers.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/http-equiv
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum HttpEquiv: string
+{
+    /**
+     * `content-security-policy` — Specifies the content security policy for the document.
+     */
+    case CONTENT_SECURITY_POLICY = 'content-security-policy';
+
+    /**
+     * `content-type` — Specifies the MIME type and character encoding of the document.
+     */
+    case CONTENT_TYPE = 'content-type';
+
+    /**
+     * `default-style` — Specifies the preferred stylesheet to use.
+     */
+    case DEFAULT_STYLE = 'default-style';
+
+    /**
+     * `refresh` — Specifies the time in seconds to refresh the page or redirect to another page.
+     */
+    case REFRESH = 'refresh';
+
+    /**
+     * `x-ua-compatible` — Specifies the document mode for Internet Explorer.
+     */
+    case X_UA_COMPATIBLE = 'x-ua-compatible';
+}

--- a/tests/HasHttpEquivTest.php
+++ b/tests/HasHttpEquivTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasHttpEquiv;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\HttpEquivProvider;
+use UIAwesome\Html\Attribute\Values\{Attribute, HttpEquiv};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasHttpEquiv} trait managing the `http-equiv` HTML attribute.
+ *
+ * Verifies rendered output, immutability, attribute override, and validation behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `http-equiv` attribute is not provided.
+ * - Sets the `http-equiv` HTML attribute and renders the expected output.
+ * - Throws an exception when the `http-equiv` attribute value is invalid.
+ *
+ * {@see HttpEquivProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasHttpEquivTest extends TestCase
+{
+    public function testReturnEmptyWhenHttpEquivAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasHttpEquiv;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingHttpEquivAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasHttpEquiv;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->httpEquiv(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(HttpEquivProvider::class, 'values')]
+    public function testSetHttpEquivAttributeValue(
+        string|UnitEnum|null $httpEquiv,
+        array $attributes,
+        string|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasHttpEquiv;
+        };
+
+        $instance = $instance->attributes($attributes)->httpEquiv($httpEquiv);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::HTTP_EQUIV, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testThrowExceptionWhenSettingInvalidHttpEquivValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasHttpEquiv;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                Attribute::HTTP_EQUIV->value,
+                implode('\', \'', Enum::normalizeArray(HttpEquiv::cases())),
+            ),
+        );
+
+        $instance->httpEquiv('invalid-value');
+    }
+}

--- a/tests/Support/Provider/HttpEquivProvider.php
+++ b/tests/Support/Provider/HttpEquivProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use PHPForge\Support\EnumDataProvider;
+use UIAwesome\Html\Attribute\Values\{Attribute, HttpEquiv};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasHttpEquivTest} test cases.
+ *
+ * Provides representative input/output pairs for the `http-equiv` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class HttpEquivProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataProvider::attributeCases(HttpEquiv::class, Attribute::HTTP_EQUIV);
+
+        $staticCase = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'refresh',
+                ['http-equiv' => 'content-type'],
+                'refresh',
+                ' http-equiv="refresh"',
+                "Should return new 'http-equiv' after replacing the existing 'http-equiv' attribute.",
+            ],
+            'string' => [
+                'content-type',
+                [],
+                'content-type',
+                ' http-equiv="content-type"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['http-equiv' => 'refresh'],
+                '',
+                '',
+                "Should unset the 'http-equiv' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing the http-equiv attribute on HTML elements with validation against predefined values (content-security-policy, content-type, default-style, refresh, x-ua-compatible).

* **Tests**
  * Added comprehensive test coverage for http-equiv attribute functionality, including immutability verification and validation of invalid inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->