### PR TITLE
feat(attribute): Add `HasName` trait and `name()` method to manage `name` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Enh #49: Add `HasCharset` trait and `charset()` method to manage `charset` attribute for HTML elements (@terabytesoftw)
 - Enh #50: Add `HasContent` trait and `content()` method to manage `content` attribute for HTML elements (@terabytesoftw)
 - Enh #51: Add `HasHttpEquiv` trait and `httpEquiv()` method to manage `http-equiv` attribute for HTML elements (@terabytesoftw)
+- Enh #52: Add `HasName` trait and `name()` method to manage `name` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasName.php
+++ b/src/HasName.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\{Attribute, MetaName};
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `name` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `name` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `name` attribute and value validation.
+ *
+ * Key features.
+ * - Designed for use in meta elements.
+ * - Handles the HTML `name` attribute.
+ * - Immutable method for setting or overriding the `name` attribute.
+ * - Supports string, UnitEnum, and `null` for flexible name assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasName
+{
+    /**
+     * Sets the HTML `name` attribute for the element.
+     *
+     * Creates a new instance with the specified metadata name value.
+     *
+     * The `name` and `content` attributes can be used together to provide document metadata in terms of name-value
+     * pairs, with the `name` attribute giving the metadata name, and the `content` attribute giving the value.
+     *
+     * Standard names include `application-name`, `author`, `description`, `generator`, `keywords`, `referrer`,
+     * `theme-color`, `color-scheme`, `viewport`, `creator`, `publisher`, `robots`.
+     *
+     * @param string|UnitEnum|null $value Metadata name value to set for the element. Use standard metadata names like
+     * `viewport`, `description`, `keywords`, `author`. Can be `null` to unset the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `name` attribute.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#standard-metadata-names
+     *
+     * Usage example:
+     * ```php
+     * $element->name('viewport');
+     * $element->name(MetaName::VIEWPORT);
+     * $element->name(null);
+     * ```
+     */
+    public function name(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, MetaName::cases(), Attribute::NAME);
+
+        return $this->addAttribute(Attribute::NAME, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -199,6 +199,13 @@ enum Attribute: string
     case MULTIPLE = 'multiple';
 
     /**
+     * `name` — Specifies the metadata name for the meta element.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name
+     */
+    case NAME = 'name';
+
+    /**
      * `pattern` — Defines a regular expression which the element's value will be validated against.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/pattern

--- a/src/Values/MetaName.php
+++ b/src/Values/MetaName.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents standard metadata names for the HTML `name` attribute on `<meta>` elements.
+ *
+ * Defines the standard metadata names as enum cases based on the HTML specification.
+ *
+ * Key features.
+ * - Based on the HTML Living Standard specification.
+ * - Enum values map to standard metadata name tokens as `string` values.
+ * - Includes all standard metadata names defined by the specification.
+ *
+ * @link https://html.spec.whatwg.org/multipage/semantics.html#standard-metadata-names
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum MetaName: string
+{
+    /**
+     * `application-name` — The name of the web application that the page represents.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#meta-application-name
+     */
+    case APPLICATION_NAME = 'application-name';
+
+    /**
+     * `author` — The name of the document's author.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#meta-author
+     */
+    case AUTHOR = 'author';
+
+    /**
+     * `color-scheme` — The color scheme(s) supported by the document.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme
+     */
+    case COLOR_SCHEME = 'color-scheme';
+
+    /**
+     * `creator` — The name of the creator of the document.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#meta-creator
+     */
+    case CREATOR = 'creator';
+
+    /**
+     * `description` — A brief description of the document.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#meta-description
+     */
+    case DESCRIPTION = 'description';
+
+    /**
+     * `generator` — The identifier of the software that generated the document.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#meta-generator
+     */
+    case GENERATOR = 'generator';
+
+    /**
+     * `keywords` — A comma-separated list of keywords relevant to the document.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#meta-keywords
+     */
+    case KEYWORDS = 'keywords';
+
+    /**
+     * `publisher` — The name of the publisher of the document.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#meta-publisher
+     */
+    case PUBLISHER = 'publisher';
+
+    /**
+     * `referrer` — The default referrer policy for the document.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer
+     */
+    case REFERRER = 'referrer';
+
+    /**
+     * `robots` — Instructions for web crawlers about how to index or serve the document.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#meta-robots
+     */
+    case ROBOTS = 'robots';
+
+    /**
+     * `theme-color` — The suggested color that user agents should use to customize the
+     * display of the page or the surrounding user interface.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#meta-theme-color
+     */
+    case THEME_COLOR = 'theme-color';
+
+    /**
+     * `viewport` — The viewport metadata for the document.
+     *
+     * @link https://html.spec.whatwg.org/multipage/semantics.html#meta-viewport
+     */
+    case VIEWPORT = 'viewport';
+}

--- a/tests/HasNameTest.php
+++ b/tests/HasNameTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasName;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\NameProvider;
+use UIAwesome\Html\Attribute\Values\{Attribute, MetaName};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasName} trait managing the `name` HTML attribute.
+ *
+ * Verifies rendered output, immutability, attribute override, and validation behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `name` attribute is not provided.
+ * - Sets the `name` HTML attribute and renders the expected output.
+ * - Throws an exception when the `name` attribute value is invalid.
+ *
+ * {@see NameProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasNameTest extends TestCase
+{
+    public function testReturnEmptyWhenNameAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasName;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingNameAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasName;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->name(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(NameProvider::class, 'values')]
+    public function testSetNameAttributeValue(
+        string|UnitEnum|null $name,
+        array $attributes,
+        string|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasName;
+        };
+
+        $instance = $instance->attributes($attributes)->name($name);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::NAME, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testThrowExceptionWhenSettingInvalidNameValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasName;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-name',
+                Attribute::NAME->value,
+                implode("', '", Enum::normalizeArray(MetaName::cases())),
+            ),
+        );
+
+        $instance->name('invalid-name');
+    }
+}

--- a/tests/Support/Provider/NameProvider.php
+++ b/tests/Support/Provider/NameProvider.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use PHPForge\Support\EnumDataProvider;
+use UIAwesome\Html\Attribute\Values\{Attribute, MetaName};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasNameTest} test cases.
+ *
+ * Provides representative input/output pairs for the `name` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class NameProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataProvider::attributeCases(MetaName::class, Attribute::NAME);
+
+        $staticCase = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'description',
+                ['name' => 'viewport'],
+                'description',
+                ' name="description"',
+                "Should return new 'name' after replacing the existing 'name' attribute.",
+            ],
+            'string viewport' => [
+                'viewport',
+                [],
+                'viewport',
+                ' name="viewport"',
+                'Should return the attribute value after setting it to viewport.',
+            ],
+            'string description' => [
+                'description',
+                [],
+                'description',
+                ' name="description"',
+                'Should return the attribute value after setting it to description.',
+            ],
+            'string keywords' => [
+                'keywords',
+                [],
+                'keywords',
+                ' name="keywords"',
+                'Should return the attribute value after setting it to keywords.',
+            ],
+            'string author' => [
+                'author',
+                [],
+                'author',
+                ' name="author"',
+                'Should return the attribute value after setting it to author.',
+            ],
+            'string robots' => [
+                'robots',
+                [],
+                'robots',
+                ' name="robots"',
+                'Should return the attribute value after setting it to robots.',
+            ],
+            'unset with null' => [
+                null,
+                ['name' => 'viewport'],
+                '',
+                '',
+                "Should unset the 'name' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing the `name` attribute on HTML elements with built-in validation against standard HTML metadata names including author, description, keywords, viewport, robots, theme-color, application-name, and more.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->