### PR TITLE
feat(attribute): Add `HasDownload` trait and `download()` method to manage `download` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Enh #51: Add `HasHttpEquiv` trait and `httpEquiv()` method to manage `http-equiv` attribute for HTML elements (@terabytesoftw)
 - Enh #52: Add `HasName` trait and `name()` method to manage `name` attribute for HTML elements (@terabytesoftw)
 - Bug #53: Update documentation for various HTML attributes and their usage in elements (@terabytesoftw)
+- Enh #54: Add `HasDownload` trait and `download()` method to manage `download` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasDownload.php
+++ b/src/HasDownload.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `download` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `download` attribute on `<a>` elements.
+ *
+ * Intended for use in tags and components that require manipulation of the download attribute.
+ *
+ * Key features.
+ * - Designed for use in anchor elements.
+ * - Handles the HTML `download` attribute.
+ * - Immutable method for setting or overriding the `download` attribute.
+ * - Supports bool, string, UnitEnum, and `null` for flexible download assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#download
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasDownload
+{
+    /**
+     * Sets the HTML `download` attribute for the element.
+     *
+     * Creates a new instance with the specified download value.
+     *
+     * Causes the browser to treat the linked URL as a download. Can be used with or without a filename value:
+     * - When `true`, the browser will suggest a filename/extension generated from various sources.
+     * - When a string is provided, it suggests that value as the filename.
+     *
+     * @param bool|string|UnitEnum|null $value Download value to set for the element. Use `true` to enable download
+     * without a specific filename, a string to suggest a filename, or `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `download` attribute.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#download
+     *
+     * Usage example:
+     * ```php
+     * $element->download(true);
+     * $element->download('my-file.pdf');
+     * $element->download(null);
+     * ```
+     */
+    public function download(bool|string|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::DOWNLOAD, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -93,6 +93,13 @@ enum Attribute: string
     case DISABLED = 'disabled';
 
     /**
+     * `download` — Indicates that the hyperlink is to be used for downloading a resource.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#download
+     */
+    case DOWNLOAD = 'download';
+
+    /**
      * `elementtiming` — Marks the element for observation by the `PerformanceElementTiming` API.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/elementtiming

--- a/tests/HasDownloadTest.php
+++ b/tests/HasDownloadTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasDownload;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\DownloadProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasDownload} trait managing the `download` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `download` attribute is not provided.
+ * - Sets the `download` HTML attribute and renders the expected output.
+ *
+ * {@see DownloadProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasDownloadTest extends TestCase
+{
+    public function testReturnEmptyWhenDownloadAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasDownload;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingDownloadAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasDownload;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->download(true),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(DownloadProvider::class, 'values')]
+    public function testSetDownloadAttributeValue(
+        bool|string|null $download,
+        array $attributes,
+        bool|string $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasDownload;
+        };
+
+        $instance = $instance->attributes($attributes)->download($download);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::DOWNLOAD, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/DownloadProvider.php
+++ b/tests/Support/Provider/DownloadProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasDownloadTest} test cases.
+ *
+ * Provides representative input/output pairs for the `download` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class DownloadProvider
+{
+    /**
+     * @phpstan-return array<string, array{bool|string|null, mixed[], bool|string, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'boolean true' => [
+                true,
+                [],
+                true,
+                ' download',
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean false' => [
+                false,
+                [],
+                false,
+                '',
+                'Should return the attribute value after setting it.',
+            ],
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'new-file.pdf',
+                ['download' => 'old-file.pdf'],
+                'new-file.pdf',
+                ' download="new-file.pdf"',
+                "Should return new 'download' after replacing the existing 'download' attribute.",
+            ],
+            'string' => [
+                'my-file.pdf',
+                [],
+                'my-file.pdf',
+                ' download="my-file.pdf"',
+                'Should return the attribute value after setting it to a filename.',
+            ],
+            'unset with null' => [
+                null,
+                ['download' => 'file.pdf'],
+                '',
+                '',
+                "Should unset the 'download' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for managing the `download` attribute on HTML elements with flexible value support and an immutable API design.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->