### PR TITLE
feat(attribute): Add `HasPing` trait and `ping()` method to manage `ping` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Enh #52: Add `HasName` trait and `name()` method to manage `name` attribute for HTML elements (@terabytesoftw)
 - Bug #53: Update documentation for various HTML attributes and their usage in elements (@terabytesoftw)
 - Enh #54: Add `HasDownload` trait and `download()` method to manage `download` attribute for HTML elements (@terabytesoftw)
+- Enh #55: Add `HasPing` trait and `ping()` method to manage `ping` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasPing.php
+++ b/src/HasPing.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `ping` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `ping` attribute on `<a>` elements.
+ *
+ * Intended for use in tags and components that require manipulation of the ping attribute.
+ *
+ * Key features.
+ * - Designed for use in anchor elements.
+ * - Handles the HTML `ping` attribute.
+ * - Immutable method for setting or overriding the `ping` attribute.
+ * - Supports string, UnitEnum, and `null` for flexible ping assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#ping
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasPing
+{
+    /**
+     * Sets the HTML `ping` attribute for the element.
+     *
+     * Creates a new instance with the specified ping value.
+     *
+     * A space-separated list of URLs. When the link is followed, the browser will send POST requests with the body
+     * `PING` to the URLs. Typically used for tracking.
+     *
+     * @param string|UnitEnum|null $value Ping value to set for the element. Use a space-separated list of URLs as a
+     * `string`. Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `ping` attribute.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#ping
+     *
+     * Usage example:
+     * ```php
+     * $element->ping('https://example.com/track');
+     * $element->ping('https://a.example/track https://b.example/track');
+     * $element->ping(null);
+     * ```
+     */
+    public function ping(string|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::PING, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -220,6 +220,13 @@ enum Attribute: string
     case PATTERN = 'pattern';
 
     /**
+     * `ping` — A space-separated list of URLs to which the browser will send POST requests when the link is followed.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#ping
+     */
+    case PING = 'ping';
+
+    /**
      * `placeholder` — Provides a hint to the user of what can be entered in the field.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/placeholder

--- a/tests/HasPingTest.php
+++ b/tests/HasPingTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasPing;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\PingProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasPing} trait managing the `ping` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `ping` attribute is not provided.
+ * - Sets the `ping` HTML attribute and renders the expected output.
+ *
+ * {@see PingProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasPingTest extends TestCase
+{
+    public function testReturnEmptyWhenPingAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasPing;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingPingAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasPing;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->ping('https://example.com/track'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(PingProvider::class, 'values')]
+    public function testSetPingAttributeValue(
+        string|null $ping,
+        array $attributes,
+        string $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasPing;
+        };
+
+        $instance = $instance->attributes($attributes)->ping($ping);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::PING, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/PingProvider.php
+++ b/tests/Support/Provider/PingProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasPingTest} test cases.
+ *
+ * Provides representative input/output pairs for the `ping` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class PingProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|null, mixed[], string, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'https://new.example/track',
+                ['ping' => 'https://old.example/track'],
+                'https://new.example/track',
+                ' ping="https://new.example/track"',
+                "Should return new 'ping' after replacing the existing 'ping' attribute.",
+            ],
+            'string' => [
+                'https://example.com/track',
+                [],
+                'https://example.com/track',
+                ' ping="https://example.com/track"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string with multiple urls' => [
+                'https://a.example/track https://b.example/track',
+                [],
+                'https://a.example/track https://b.example/track',
+                ' ping="https://a.example/track https://b.example/track"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['ping' => 'https://example.com/track'],
+                '',
+                '',
+                "Should unset the 'ping' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the HTML `ping` attribute on elements. This allows you to specify URLs that should be notified when users interact with supported elements, enabling enhanced interaction tracking capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->