### PR TITLE
feat(attribute): Add `HasLoading` trait and `loading()` method to manage `loading` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Bug #53: Update documentation for various HTML attributes and their usage in elements (@terabytesoftw)
 - Enh #54: Add `HasDownload` trait and `download()` method to manage `download` attribute for HTML elements (@terabytesoftw)
 - Enh #55: Add `HasPing` trait and `ping()` method to manage `ping` attribute for HTML elements (@terabytesoftw)
+- Enh #56: Add `HasLoading` trait and `loading()` method to manage `loading` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/Element/HasLoading.php
+++ b/src/Element/HasLoading.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Element;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\{ElementAttribute, Loading};
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `loading` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `loading` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the loading attribute and value validation.
+ *
+ * Key features.
+ * - Designed for use in image elements (img, iframe) requiring loading strategy assignment.
+ * - Handles the HTML `loading` attribute.
+ * - Immutable method for setting or overriding the `loading` attribute.
+ * - Supports string, UnitEnum, and `null` for flexible loading strategy assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#loading
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasLoading
+{
+    /**
+     * Sets the HTML `loading` attribute for the element.
+     *
+     * Creates a new instance with the specified loading strategy value.
+     *
+     * Indicates how the browser should load the image.
+     * - Use `eager` to load the image immediately, regardless of whether or not the image is currently within the
+     *   visible viewport (this is the default value).
+     * - Use `lazy` to defer loading of the image until it reaches a calculated distance from the viewport, as defined
+     *   by the browser.
+     *
+     * @param string|UnitEnum|null $value Loading strategy value to set for the element. Use `eager` for immediate
+     * loading, or `lazy` for deferred loading. Can be `null` to unset the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `loading` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->loading('lazy');
+     * $element->loading(Loading::LAZY);
+     * $element->loading(null);
+     * ```
+     */
+    public function loading(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, Loading::cases(), ElementAttribute::LOADING);
+
+        return $this->addAttribute(ElementAttribute::LOADING, $value);
+    }
+}

--- a/src/Values/ElementAttribute.php
+++ b/src/Values/ElementAttribute.php
@@ -45,20 +45,20 @@ enum ElementAttribute: string
     case HEIGHT = 'height';
 
     /**
-     * `loading` — Indicates how the browser should load the image.
-     *
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#loading
-     */
-    case LOADING = 'loading';
-
-    /**
      * `href` — The URL of a linked resource.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#href
      * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/href
      */
     case HREF = 'href';
+
+    /**
+     * `loading` — Indicates how the browser should load the image.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#loading
+     */
+    case LOADING = 'loading';
 
     /**
      * `referrerpolicy` — Referrer information to send when fetching the resource.

--- a/src/Values/ElementAttribute.php
+++ b/src/Values/ElementAttribute.php
@@ -45,6 +45,14 @@ enum ElementAttribute: string
     case HEIGHT = 'height';
 
     /**
+     * `loading` — Indicates how the browser should load the image.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#loading
+     */
+    case LOADING = 'loading';
+
+    /**
      * `href` — The URL of a linked resource.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#href

--- a/src/Values/Loading.php
+++ b/src/Values/Loading.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents values for the HTML `loading` attribute on `<img>` elements.
+ *
+ * Defines the supported loading strategy tokens as enum cases.
+ *
+ * Key features.
+ * - Designed for use in image elements requiring loading strategy assignment.
+ * - Enum values are represented as `string` tokens.
+ * - Enum values map to `eager` and `lazy`.
+ * - Integration-ready for tag rendering and element generation APIs.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#loading
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Loading: string
+{
+    /**
+     * Load the image immediately, regardless of whether or not the image is currently within the visible viewport
+     * (`eager`).
+     *
+     * This is the default value.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#eager
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#eager
+     */
+    case EAGER = 'eager';
+
+    /**
+     * Defer loading of the image until it reaches a calculated distance from the viewport (`lazy`).
+     *
+     * The image will be loaded when it is needed, reducing initial page load time.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#lazy
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#lazy
+     */
+    case LAZY = 'lazy';
+}

--- a/src/Values/Loading.php
+++ b/src/Values/Loading.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Attribute\Values;
 
 /**
- * Represents values for the HTML `loading` attribute on `<img>` elements.
+ * Represents values for the HTML `loading` attribute on `<img>` and `<iframe>` elements.
  *
  * Defines the supported loading strategy tokens as enum cases.
  *

--- a/tests/Element/HasLoadingTest.php
+++ b/tests/Element/HasLoadingTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Element;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Element\HasLoading;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\Element\LoadingProvider;
+use UIAwesome\Html\Attribute\Values\{ElementAttribute, Loading};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasLoading} trait managing the `loading` HTML attribute.
+ *
+ * Verifies rendered output, immutability, attribute override, and validation behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `loading` attribute is not provided.
+ * - Sets the `loading` HTML attribute and renders the expected output.
+ * - Throws an exception when the `loading` attribute value is invalid.
+ *
+ * {@see LoadingProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('element')]
+final class HasLoadingTest extends TestCase
+{
+    public function testReturnEmptyWhenLoadingAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasLoading;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingLoadingAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasLoading;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->loading(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(LoadingProvider::class, 'values')]
+    public function testSetLoadingAttributeValue(
+        string|UnitEnum|null $loading,
+        array $attributes,
+        string|UnitEnum $expectedValue,
+        string $expectedRenderAttribute,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasLoading;
+        };
+
+        $instance = $instance->attributes($attributes)->loading($loading);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(ElementAttribute::LOADING, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttribute,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingLoadingValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasLoading;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                ElementAttribute::LOADING->value,
+                implode("', '", Enum::normalizeArray(Loading::cases())),
+            ),
+        );
+
+        $instance->loading('invalid-value');
+    }
+}

--- a/tests/Support/Provider/Element/LoadingProvider.php
+++ b/tests/Support/Provider/Element/LoadingProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider\Element;
+
+use PHPForge\Support\EnumDataProvider;
+use UIAwesome\Html\Attribute\Values\{ElementAttribute, Loading};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Element\HasLoadingTest} test cases.
+ *
+ * Provides representative input/output pairs for the `loading` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class LoadingProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataProvider::attributeCases(Loading::class, ElementAttribute::LOADING);
+
+        $staticCase = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'lazy',
+                ['loading' => 'eager'],
+                'lazy',
+                ' loading="lazy"',
+                "Should return new 'loading' after replacing the existing 'loading' attribute.",
+            ],
+            'string' => [
+                'eager',
+                [],
+                'eager',
+                ' loading="eager"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['loading' => 'lazy'],
+                '',
+                '',
+                "Should unset the 'loading' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the HTML loading attribute (eager|lazy|null) for images and iframes to control when resources are fetched, improving load behavior and performance.

* **Tests**
  * Added tests covering setting, unsetting, immutability, rendering, and invalid-value validation for the loading attribute.

* **Documentation**
  * Updated changelog to document the new loading attribute feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->