### PR TITLE
feat(attribute): Add `HasSrcset` trait and `srcset()` method to manage `srcset` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Enh #54: Add `HasDownload` trait and `download()` method to manage `download` attribute for HTML elements (@terabytesoftw)
 - Enh #55: Add `HasPing` trait and `ping()` method to manage `ping` attribute for HTML elements (@terabytesoftw)
 - Enh #56: Add `HasLoading` trait and `loading()` method to manage `loading` attribute for HTML elements (@terabytesoftw)
+- Enh #57: Add `HasSrcset` trait and `srcset()` method to manage `srcset` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/Element/HasSrcset.php
+++ b/src/Element/HasSrcset.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Element;
+
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `srcset` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `srcset` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `srcset` attribute.
+ *
+ * Key features.
+ * - Designed for use in image elements (img) requiring responsive image source sets.
+ * - Handles the HTML `srcset` attribute.
+ * - Immutable method for setting or overriding the `srcset` attribute.
+ * - Supports string and `null` for flexible source set assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#srcset
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/picture#the_srcset_attribute
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source#srcset
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasSrcset
+{
+    /**
+     * Sets the HTML `srcset` attribute for the element.
+     *
+     * Creates a new instance with the specified source set value, supporting explicit assignment according to the HTML
+     * specification for responsive images.
+     *
+     * The `srcset` attribute defines a set of images for the browser to choose from, along with information about the
+     * sizes of each image. The browser selects the most appropriate image based on the current viewport size, pixel
+     * density, and other factors. Each image in the set is specified with a URL and either a width descriptor ('w') or
+     * pixel density descriptor ('x').
+     *
+     * @param string|UnitEnum|null $value Source set descriptor to set for the element. Use comma-separated image URLs
+     * with size descriptors (for example, "small.jpg 480w, medium.jpg 800w, large.jpg 1200w"). Can be `null` to unset
+     * the attribute.
+     *
+     * @return static New instance with the updated `srcset` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->srcset('small.jpg 480w, medium.jpg 800w, large.jpg 1200w');
+     * $element->srcset('image-1x.jpg 1x, image-2x.jpg 2x');
+     * $element->srcset(null);
+     * ```
+     */
+    public function srcset(string|UnitEnum|null $value): static
+    {
+        return $this->addAttribute('srcset', $value);
+    }
+}

--- a/src/Values/ElementAttribute.php
+++ b/src/Values/ElementAttribute.php
@@ -55,8 +55,8 @@ enum ElementAttribute: string
     /**
      * `loading` — Indicates how the browser should load the image.
      *
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#loading
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading
      */
     case LOADING = 'loading';
 
@@ -73,6 +73,16 @@ enum ElementAttribute: string
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#src
      */
     case SRC = 'src';
+
+
+    /**
+     * `srcset` — Defines a set of images for the browser to choose from.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture#srcset
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#srcset
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source#srcset
+     */
+    case SRCSET = 'srcset';
 
     /**
      * `width` — Specifies the width of certain elements.

--- a/tests/Element/HasSrcsetTest.php
+++ b/tests/Element/HasSrcsetTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Element;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Element\HasSrcset;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\Element\SrcsetProvider;
+use UIAwesome\Html\Attribute\Values\ElementAttribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasSrcset} trait managing the `srcset` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `srcset` attribute is not provided.
+ * - Sets the `srcset` HTML attribute and renders the expected output.
+ *
+ * {@see SrcsetProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('element')]
+final class HasSrcsetTest extends TestCase
+{
+    public function testReturnEmptyWhenSrcsetAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasSrcset;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingSrcsetAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasSrcset;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->srcset(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(SrcsetProvider::class, 'values')]
+    public function testSetSrcsetAttributeValue(
+        string|null $srcset,
+        array $attributes,
+        string $expectedValue,
+        string $expectedRenderAttribute,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasSrcset;
+        };
+
+        $instance = $instance->attributes($attributes)->srcset($srcset);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(ElementAttribute::SRCSET, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttribute,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/Element/SrcsetProvider.php
+++ b/tests/Support/Provider/Element/SrcsetProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider\Element;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Element\HasSrcsetTest} test cases.
+ *
+ * Provides representative input/output pairs for the `srcset` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class SrcsetProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|null, mixed[], string, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'small.jpg 480w, medium.jpg 800w',
+                ['srcset' => 'old-small.jpg 480w, old-medium.jpg 800w'],
+                'small.jpg 480w, medium.jpg 800w',
+                ' srcset="small.jpg 480w, medium.jpg 800w"',
+                "Should return new 'srcset' after replacing the existing 'srcset' attribute.",
+            ],
+            'string' => [
+                'small.jpg 480w, medium.jpg 800w, large.jpg 1200w',
+                [],
+                'small.jpg 480w, medium.jpg 800w, large.jpg 1200w',
+                ' srcset="small.jpg 480w, medium.jpg 800w, large.jpg 1200w"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string with pixel density descriptors' => [
+                'image-1x.jpg 1x, image-2x.jpg 2x',
+                [],
+                'image-1x.jpg 1x, image-2x.jpg 2x',
+                ' srcset="image-1x.jpg 1x, image-2x.jpg 2x"',
+                'Should return the attribute value with pixel density descriptors after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['srcset' => 'small.jpg 480w, medium.jpg 800w'],
+                '',
+                '',
+                "Should unset the 'srcset' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the HTML srcset attribute, enabling configuration of responsive image sources on image elements through a new fluent API.

* **Tests**
  * Added comprehensive test coverage with immutability validation and attribute rendering verification scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->