### PR TITLE
feat(attribute): Add `HasUsemap` trait and `usemap()` method to manage `usemap` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Enh #55: Add `HasPing` trait and `ping()` method to manage `ping` attribute for HTML elements (@terabytesoftw)
 - Enh #56: Add `HasLoading` trait and `loading()` method to manage `loading` attribute for HTML elements (@terabytesoftw)
 - Enh #57: Add `HasSrcset` trait and `srcset()` method to manage `srcset` attribute for HTML elements (@terabytesoftw)
+- Enh #58: Add `HasUsemap` trait and `usemap()` method to manage `usemap` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/Element/HasUsemap.php
+++ b/src/Element/HasUsemap.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Element;
+
+use UIAwesome\Html\Attribute\Values\ElementAttribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `usemap` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `usemap` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `usemap` attribute.
+ *
+ * Key features.
+ * - Designed for use in image elements (img) requiring client-side image map assignment.
+ * - Handles the HTML `usemap` attribute.
+ * - Immutable method for setting or overriding the `usemap` attribute.
+ * - Supports string, `UnitEnum`, and `null` for flexible image map reference assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#usemap
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasUsemap
+{
+    /**
+     * Sets the HTML `usemap` attribute for the element.
+     *
+     * Creates a new instance with the specified image map reference value, supporting explicit assignment according to
+     * the HTML specification for client-side image maps.
+     *
+     * The `usemap` attribute associates the image with a `<map>` element, creating a client-side image map. The value
+     * must be a valid hash-name reference to a `<map>` element in the same document (for example, "#mapname").
+     *
+     * @param string|UnitEnum|null $value Image map reference to set for the element. Use a hash-name reference
+     * (for example, "#mapname") that matches the `name` attribute of a `<map>` element. Can be `null` to unset the
+     * attribute.
+     *
+     * @return static New instance with the updated `usemap` attribute.
+     *
+     * @link https://html.spec.whatwg.org/multipage/embedded-content.html#attr-hyperlink-usemap
+     *
+     * Usage example:
+     * ```php
+     * $element->usemap('#imagemap');
+     * $element->usemap(null);
+     * ```
+     */
+    public function usemap(string|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(ElementAttribute::USEMAP, $value);
+    }
+}

--- a/src/Values/ElementAttribute.php
+++ b/src/Values/ElementAttribute.php
@@ -85,6 +85,13 @@ enum ElementAttribute: string
     case SRCSET = 'srcset';
 
     /**
+     * `usemap` — Associates the image with a `<map>` element.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#usemap
+     */
+    case USEMAP = 'usemap';
+
+    /**
      * `width` — Specifies the width of certain elements.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#width

--- a/tests/Element/HasUsemapTest.php
+++ b/tests/Element/HasUsemapTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Element;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Element\HasUsemap;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\Element\UsemapProvider;
+use UIAwesome\Html\Attribute\Values\ElementAttribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasUsemap} trait managing the `usemap` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `usemap` attribute is not provided.
+ * - Sets the `usemap` HTML attribute and renders the expected output.
+ *
+ * {@see UsemapProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('element')]
+final class HasUsemapTest extends TestCase
+{
+    public function testReturnEmptyWhenUsemapAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasUsemap;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingUsemapAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasUsemap;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->usemap(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(UsemapProvider::class, 'values')]
+    public function testSetUsemapAttributeValue(
+        string|null $usemap,
+        array $attributes,
+        string $expectedValue,
+        string $expectedRenderAttribute,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasUsemap;
+        };
+
+        $instance = $instance->attributes($attributes)->usemap($usemap);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(ElementAttribute::USEMAP, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttribute,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/Element/UsemapProvider.php
+++ b/tests/Support/Provider/Element/UsemapProvider.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider\Element;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Element\HasUsemapTest} test cases.
+ *
+ * Provides representative input/output pairs for the `usemap` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class UsemapProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|null, mixed[], string, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                '#new-map',
+                ['usemap' => '#old-map'],
+                '#new-map',
+                ' usemap="#new-map"',
+                "Should return new 'usemap' after replacing the existing 'usemap' attribute.",
+            ],
+            'string' => [
+                '#imagemap',
+                [],
+                '#imagemap',
+                ' usemap="#imagemap"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['usemap' => '#imagemap'],
+                '',
+                '',
+                "Should unset the 'usemap' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the HTML `usemap` attribute on elements.
  * Enables linking images to corresponding image maps via reference.
  * Supports flexible input including string values, enums, or null to unset.
  * Follows immutable design; returns a new instance when modified.

* **Tests**
  * Added comprehensive test coverage for new usemap functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->