### PR TITLE
feat(attribute): Add `HasValue` trait and `value()` method to manage `value` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Enh #56: Add `HasLoading` trait and `loading()` method to manage `loading` attribute for HTML elements (@terabytesoftw)
 - Enh #57: Add `HasSrcset` trait and `srcset()` method to manage `srcset` attribute for HTML elements (@terabytesoftw)
 - Enh #58: Add `HasUsemap` trait and `usemap()` method to manage `usemap` attribute for HTML elements (@terabytesoftw)
+- Enh #59: Add `HasValue` trait and `value()` method to manage `value` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasValue.php
+++ b/src/HasValue.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `value` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `value` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `value` attribute.
+ *
+ * Key features.
+ * - Designed for use in elements that require a `value` attribute (for example, `<li>`, `<input>`, `<option>`,
+ *   `<progress>`, `<meter>`).
+ * - Handles the HTML `value` attribute for setting element values.
+ * - Immutable method for setting or overriding the `value` attribute.
+ * - Supports float, int, string, Stringable, UnitEnum, and `null` for flexible value assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/value
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasValue
+{
+    /**
+     * Sets the HTML `value` attribute for the element.
+     *
+     * Creates a new instance with the specified value.
+     *
+     * The `value` attribute contains the current value of the element. Its meaning depends on the context:
+     * - For `<li>`: the ordinal value in an ordered list.
+     * - For `<input>`: the current value of the form control.
+     * - For `<option>`: the value to be submitted with the form.
+     * - For `<progress>` and `<meter>`: the current value of the range.
+     *
+     * @param float|int|string|Stringable|UnitEnum|null $value The value to set for the element. Can be `null` to unset the
+     * attribute.
+     *
+     * @return static New instance with the updated `value` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->value(3);
+     * $element->value(3.14);
+     * $element->value('text');
+     * $element->value(SomeEnum::VALUE);
+     * $element->value(null);
+     * ```
+     */
+    public function value(float|int|string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::VALUE, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -302,4 +302,11 @@ enum Attribute: string
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/type
      */
     case TYPE = 'type';
+
+    /**
+     * `value` — Indicates the current ordinal value of the list item.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/li#value
+     */
+    case VALUE = 'value';
 }

--- a/tests/HasValueTest.php
+++ b/tests/HasValueTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasValue;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\ValueProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasValue} trait managing the `value` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior for the `value` attribute.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `value` attribute is not provided.
+ * - Sets the `value` HTML attribute with string, int, and null values and renders the expected output.
+ *
+ * {@see ValueProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasValueTest extends TestCase
+{
+    public function testReturnEmptyWhenValueAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasValue;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingValueAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasValue;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->value('test'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(ValueProvider::class, 'values')]
+    public function testSetValueAttributeValue(
+        float|int|string|UnitEnum|null $value,
+        array $attributes,
+        float|int|string $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasValue;
+        };
+
+        $instance = $instance->attributes($attributes)->value($value);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::VALUE, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/ValueProvider.php
+++ b/tests/Support/Provider/ValueProvider.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasValueTest} test cases.
+ *
+ * Provides representative input/output pairs for the `value` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ValueProvider
+{
+    /**
+     * @phpstan-return array<string, array{float|int|string|UnitEnum|null, mixed[], float|int|string, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return empty when setting an empty string.',
+            ],
+            'float' => [
+                3.14,
+                [],
+                3.14,
+                ' value="3.14"',
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                3,
+                [],
+                3,
+                ' value="3"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                5,
+                ['value' => 2],
+                5,
+                ' value="5"',
+                "Should return new 'value' after replacing the existing 'value' attribute.",
+            ],
+            'string' => [
+                'text-value',
+                [],
+                'text-value',
+                ' value="text-value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string with spaces' => [
+                'text with spaces',
+                [],
+                'text with spaces',
+                ' value="text with spaces"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['value' => 10],
+                '',
+                '',
+                "Should unset the 'value' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new immutable API for managing the HTML value attribute on elements, supporting multiple value types including floats, integers, strings, and null to enable flexible element configuration.

* **Tests**
  * Added comprehensive unit tests ensuring immutability guarantees, correct attribute rendering with various data types, and proper handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->