### PR TITLE
feat(attribute): Add `HasForm` trait and `form()` method to manage `form` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@
 
 ## 0.1.2 March 14, 2024
 
-- Bug #3: Change visibility poperty `attributes` to `public` in tests (@terabytesoftw)
+- Bug #3: Change visibility property `attributes` to `public` in tests (@terabytesoftw)
 - Enh #4: Add `HasAriaCurrent` trait and `ariaCurrent()` method (@terabytesoftw)
 - Bug #5: Remove dead code in `HasAriaCurrent` trait (@terabytesoftw)
 - Bug #6: Change branch alias to `1.0-dev` in `composer.json` (@terabytesoftw)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Enh #57: Add `HasSrcset` trait and `srcset()` method to manage `srcset` attribute for HTML elements (@terabytesoftw)
 - Enh #58: Add `HasUsemap` trait and `usemap()` method to manage `usemap` attribute for HTML elements (@terabytesoftw)
 - Enh #59: Add `HasValue` trait and `value()` method to manage `value` attribute for HTML elements (@terabytesoftw)
+- Enh #60: Add `HasForm` trait and `form()` method to manage `form` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasDisabled.php
+++ b/src/HasDisabled.php
@@ -14,15 +14,15 @@ use UIAwesome\Html\Attribute\Values\Attribute;
  * Intended for use in tags and components that require manipulation of the `disabled` attribute.
  *
  * Key features.
- * - Designed for use in link elements with `rel="stylesheet"`.
- * - Handles the HTML `disabled` attribute.
+ * - Designed for use in form control elements (input, select, textarea, button) and link elements.
+ * - Handles the HTML `disabled` attribute for disabling user interaction.
  * - Immutable method for setting or overriding the `disabled` attribute.
  * - Supports bool and `null` for flexible assignment.
  *
  * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
  *
- * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#disabled
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/disabled
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -34,12 +34,21 @@ trait HasDisabled
      *
      * Creates a new instance with the specified disabled state.
      *
-     * Indicates whether the described stylesheet should be loaded and applied to the document. If `disabled` is
-     * specified when the HTML is loaded, the stylesheet will not be loaded during page load. Instead, the stylesheet
-     * will be loaded on-demand, if and when the `disabled` attribute is changed to `false` or removed.
+     * The `disabled` attribute is a boolean attribute that indicates the user should not be able to interact with the
+     * element. It is valid for all input types and other form controls like select, textarea, and button.
      *
-     * @param bool|null $value Disabled state to set for the element. Use `true` to disable, `false` to enable,
-     * or `null` to unset the attribute.
+     * When applied to form controls.
+     * - Disabled controls are not focusable and do not receive `click` events.
+     * - Disabled controls are not submitted with the form.
+     * - Disabled controls are typically rendered with a dimmer color or other visual indication.
+     * - The value of a disabled control cannot be modified by the user.
+     * When applied to link elements with `rel="stylesheet"`, the stylesheet will not be loaded during page load.
+     *
+     * Note: Although not required by the specification, some browsers persist the dynamic disabled state across page
+     * loads. Use the `autocomplete` attribute to control this feature.
+     *
+     * @param bool|null $value Disabled state to set for the element. Use `true` to disable, `false` to enable. Can be
+     * `null` to unset the attribute.
      *
      * @return static New instance with the updated `disabled` attribute.
      *

--- a/src/HasForm.php
+++ b/src/HasForm.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `form` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `form` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `form` attribute.
+ *
+ * Key features.
+ * - Designed for use in form control elements (input, textarea, select, button).
+ * - Handles the HTML `form` attribute for associating controls with forms.
+ * - Immutable method for setting or overriding the `form` attribute.
+ * - Supports string, Stringable, UnitEnum, and `null` for flexible form association.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/form
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasForm
+{
+    /**
+     * Sets the HTML `form` attribute for the element.
+     *
+     * Creates a new instance with the specified form value.
+     *
+     * The `form` attribute associates the control with a form element by referencing the form's `id`. This allows form
+     * controls to be placed anywhere in the document while still being submitted with the specified form. If this
+     * attribute is not specified, the control is associated with the nearest containing form, if any.
+     *
+     * The value must match the `id` of a `<form>` element in the same document. An input can only be associated with
+     * one form.
+     *
+     * @param string|Stringable|UnitEnum|null $value Form ID to associate with the element. Can be `null` to unset the
+     * attribute.
+     *
+     * @return static New instance with the updated `form` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->form('myForm');
+     * $element->form($formId);
+     * $element->form(null);
+     * ```
+     */
+    public function form(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::FORM, $value);
+    }
+}

--- a/tests/HasDisabledTest.php
+++ b/tests/HasDisabledTest.php
@@ -64,7 +64,7 @@ final class HasDisabledTest extends TestCase
     public function testSetDisabledAttributeValue(
         bool|null $disabled,
         array $attributes,
-        bool|null $expectedValue,
+        bool|string $expectedValue,
         string $expectedRenderAttributes,
         string $message,
     ): void {
@@ -77,7 +77,7 @@ final class HasDisabledTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(Attribute::DISABLED, null),
+            $instance->getAttribute(Attribute::DISABLED, ''),
             $message,
         );
         self::assertSame(

--- a/tests/HasFormTest.php
+++ b/tests/HasFormTest.php
@@ -6,11 +6,13 @@ namespace UIAwesome\Html\Attribute\Tests;
 
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
+use Stringable;
 use UIAwesome\Html\Attribute\HasForm;
 use UIAwesome\Html\Attribute\Tests\Support\Provider\FormProvider;
 use UIAwesome\Html\Attribute\Values\Attribute;
 use UIAwesome\Html\Helper\Attributes;
 use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
 
 /**
  * Unit tests for the {@see HasForm} trait managing the `form` HTML attribute.
@@ -62,9 +64,9 @@ final class HasFormTest extends TestCase
      */
     #[DataProviderExternal(FormProvider::class, 'values')]
     public function testSetFormAttributeValue(
-        string|null $form,
+        string|Stringable|UnitEnum|null $form,
         array $attributes,
-        string|null $expectedValue,
+        string|Stringable|UnitEnum $expectedValue,
         string $expectedRenderAttributes,
         string $message,
     ): void {

--- a/tests/HasFormTest.php
+++ b/tests/HasFormTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasForm;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\FormProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasForm} trait managing the `form` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `form` attribute is not provided.
+ * - Sets the `form` HTML attribute and renders the expected output.
+ *
+ * {@see FormProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasFormTest extends TestCase
+{
+    public function testReturnEmptyWhenFormAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasForm;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingFormAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasForm;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->form(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(FormProvider::class, 'values')]
+    public function testSetFormAttributeValue(
+        string|null $form,
+        array $attributes,
+        string|null $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasForm;
+        };
+
+        $instance = $instance->attributes($attributes)->form($form);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::FORM, null),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/HasFormTest.php
+++ b/tests/HasFormTest.php
@@ -77,7 +77,7 @@ final class HasFormTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(Attribute::FORM, null),
+            $instance->getAttribute(Attribute::FORM, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Support/Provider/DisabledProvider.php
+++ b/tests/Support/Provider/DisabledProvider.php
@@ -22,26 +22,26 @@ final class DisabledProvider
     public static function values(): array
     {
         return [
+            'boolean false' => [
+                false,
+                [],
+                false,
+                '',
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                true,
+                [],
+                true,
+                ' disabled',
+                'Should return the attribute value after setting it.',
+            ],
             'null' => [
                 null,
                 [],
                 null,
                 '',
                 "Should return an empty string when the attribute is set to 'null'.",
-            ],
-            'true' => [
-                true,
-                [],
-                true,
-                ' disabled',
-                'Should return the attribute value after setting it to true.',
-            ],
-            'false' => [
-                false,
-                [],
-                false,
-                '',
-                'Should return empty string when setting false (boolean attribute).',
             ],
             'replace existing' => [
                 true,

--- a/tests/Support/Provider/DisabledProvider.php
+++ b/tests/Support/Provider/DisabledProvider.php
@@ -17,7 +17,7 @@ use UIAwesome\Html\Attribute\Values\Attribute;
 final class DisabledProvider
 {
     /**
-     * @phpstan-return array<string, array{bool|null, mixed[], bool|null, string, string}>
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|string, string, string}>
      */
     public static function values(): array
     {
@@ -39,7 +39,7 @@ final class DisabledProvider
             'null' => [
                 null,
                 [],
-                null,
+                '',
                 '',
                 "Should return an empty string when the attribute is set to 'null'.",
             ],
@@ -53,7 +53,7 @@ final class DisabledProvider
             'unset with null' => [
                 null,
                 ['disabled' => true],
-                null,
+                '',
                 '',
                 "Should unset the 'disabled' attribute when 'null' is provided after a value.",
             ],

--- a/tests/Support/Provider/FormProvider.php
+++ b/tests/Support/Provider/FormProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use Stringable;
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasFormTest} test cases.
+ *
+ * Provides representative input/output pairs for the `form` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class FormProvider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{string|Stringable|UnitEnum|null, mixed[], string|Stringable|UnitEnum, string, string},
+     * >
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'string' => [
+                'myForm',
+                [],
+                'myForm',
+                ' form="myForm"',
+                'Should return the attribute value after setting it.',
+            ],
+            'replace existing' => [
+                'myForm',
+                ['form' => 'oldForm'],
+                'myForm',
+                ' form="myForm"',
+                "Should return new 'form' after replacing the existing 'form' attribute.",
+            ],
+            'unset with null' => [
+                null,
+                ['form' => 'myForm'],
+                '',
+                '',
+                "Should unset the 'form' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}

--- a/tests/Support/Provider/FormProvider.php
+++ b/tests/Support/Provider/FormProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
 
 use Stringable;
+use UIAwesome\Html\Attribute\Tests\Support\Stub\Values\Status;
 use UnitEnum;
 
 /**
@@ -25,6 +26,13 @@ final class FormProvider
      */
     public static function values(): array
     {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'form-id';
+            }
+        };
+
         return [
             'empty string' => [
                 '',
@@ -32,6 +40,13 @@ final class FormProvider
                 '',
                 '',
                 'Should return an empty string when setting an empty string.',
+            ],
+            'enum' => [
+                Status::ACTIVE,
+                [],
+                Status::ACTIVE,
+                ' form="active"',
+                'Should return the attribute value after setting it.',
             ],
             'null' => [
                 null,
@@ -46,6 +61,13 @@ final class FormProvider
                 'myForm',
                 ' form="myForm"',
                 'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' form="form-id"',
+                'Should return the attribute value after setting it with a Stringable instance.',
             ],
             'replace existing' => [
                 'myForm',


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added form attribute management capability for HTML elements.

* **Documentation**
  * Broadened disabled attribute docs for form controls and links; clarified behavior and examples.
  * Added changelog entry documenting the form feature.

* **Tests**
  * Added comprehensive tests for form attribute behavior and a new data provider; updated related test provider cases and expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->