### PR TITLE
feat(attribute): Add `Type` enum for common `type` attribute values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Enh #58: Add `HasUsemap` trait and `usemap()` method to manage `usemap` attribute for HTML elements (@terabytesoftw)
 - Enh #59: Add `HasValue` trait and `value()` method to manage `value` attribute for HTML elements (@terabytesoftw)
 - Enh #60: Add `HasForm` trait and `form()` method to manage `form` attribute for HTML elements (@terabytesoftw)
+- Enh #61: Add `Type` enum for common `type` attribute values (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasType.php
+++ b/src/HasType.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Attribute;
 
+use InvalidArgumentException;
 use Stringable;
-use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Attribute\Values\{Attribute, Type};
+use UIAwesome\Html\Helper\Validator;
 use UnitEnum;
 
 /**
@@ -45,6 +47,8 @@ trait HasType
      * @param string|Stringable|UnitEnum|null $value Type value to set for the element. Use MIME types (for example,
      * `text/css`, `text/javascript`) or element-specific type values. Can be `null` to unset the attribute.
      *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
      * @return static New instance with the updated `type` attribute.
      *
      * Usage example:
@@ -56,6 +60,8 @@ trait HasType
      */
     public function type(string|Stringable|UnitEnum|null $value): static
     {
+        Validator::oneOf($value, Type::cases(), Attribute::TYPE);
+
         return $this->addAttribute(Attribute::TYPE, $value);
     }
 }

--- a/src/Values/Type.php
+++ b/src/Values/Type.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents values for the HTML `type` attribute.
+ *
+ * Defines a curated set of `type` tokens as enum cases for use with elements that support a finite set of values (for
+ * example, input, button, script, and ol). Some elements interpret `type` as a MIME type (for example, link, embed,
+ * object, and source), which is not an exhaustive token set.
+ *
+ * Key features.
+ * - Designed for use in tags, components, and helpers requiring `type` attribute assignment.
+ * - Enum values map to `type` tokens as `string` values.
+ * - Suitable for rendering HTML attributes in view helpers and components.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/type
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Type: string
+{
+    /**
+     * `button` — Push button type for `<input>` and `<button>` elements.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#type
+     */
+    case BUTTON = 'button';
+
+    /**
+     * `checkbox` — Check box input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/checkbox
+     */
+    case CHECKBOX = 'checkbox';
+
+    /**
+     * `color` — Color picker input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/color
+     */
+    case COLOR = 'color';
+
+    /**
+     * `date` — Date input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/date
+     */
+    case DATE = 'date';
+
+    /**
+     * `datetime-local` — Date and time input control without a time zone (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/datetime-local
+     */
+    case DATETIME_LOCAL = 'datetime-local';
+
+    /**
+     * `1` — Decimal numbering for `<ol>` elements.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ol#type
+     */
+    case DECIMAL = '1';
+
+    /**
+     * `email` — Email address input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/email
+     */
+    case EMAIL = 'email';
+
+    /**
+     * `file` — File selection input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/file
+     */
+    case FILE = 'file';
+
+    /**
+     * `hidden` — Hidden input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/hidden
+     */
+    case HIDDEN = 'hidden';
+
+    /**
+     * `image` — Graphical submit button (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/image
+     */
+    case IMAGE = 'image';
+
+    /**
+     * `importmap` — Indicates that the script body contains an import map (`<script>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap
+     */
+    case IMPORTMAP = 'importmap';
+
+    /**
+     * `a` — Lowercase letter numbering for `<ol>` elements.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ol#type
+     */
+    case LOWER_ALPHA = 'a';
+
+    /**
+     * `i` — Lowercase Roman numeral numbering for `<ol>` elements.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ol#type
+     */
+    case LOWER_ROMAN = 'i';
+
+    /**
+     * `module` — Treats the script as a JavaScript module (`<script>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type
+     */
+    case MODULE = 'module';
+
+    /**
+     * `month` — Month and year input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/month
+     */
+    case MONTH = 'month';
+
+    /**
+     * `number` — Numeric input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/number
+     */
+    case NUMBER = 'number';
+
+    /**
+     * `password` — Password input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/password
+     */
+    case PASSWORD = 'password';
+
+    /**
+     * `radio` — Radio button input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/radio
+     */
+    case RADIO = 'radio';
+
+    /**
+     * `range` — Slider control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/range
+     */
+    case RANGE = 'range';
+
+    /**
+     * `reset` — Resets the form to its initial values (`<input>` and `<button>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#type
+     */
+    case RESET = 'reset';
+
+    /**
+     * `search` — Search input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/search
+     */
+    case SEARCH = 'search';
+
+    /**
+     * `speculationrules` — Indicates that the script body contains speculation rules (`<script>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/speculationrules
+     */
+    case SPECULATIONRULES = 'speculationrules';
+
+    /**
+     * `submit` — Submits the form (`<input>` and `<button>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#type
+     */
+    case SUBMIT = 'submit';
+
+    /**
+     * `tel` — Telephone number input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/tel
+     */
+    case TEL = 'tel';
+
+    /**
+     * `text` — Single-line text input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/text
+     */
+    case TEXT = 'text';
+
+    /**
+     * `text/css` — CSS MIME type used by `<style>` and other elements that interpret `type` as a MIME type.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style#type
+     */
+    case TEXT_CSS = 'text/css';
+
+    /**
+     * `text/javascript` — JavaScript MIME type used by `<script>` and other elements that interpret `type` as a MIME type.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type
+     */
+    case TEXT_JAVASCRIPT = 'text/javascript';
+
+    /**
+     * `time` — Time input control without a time zone (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/time
+     */
+    case TIME = 'time';
+
+    /**
+     * `A` — Uppercase letter numbering for `<ol>` elements.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ol#type
+     */
+    case UPPER_ALPHA = 'A';
+
+    /**
+     * `I` — Uppercase Roman numeral numbering for `<ol>` elements.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ol#type
+     */
+    case UPPER_ROMAN = 'I';
+
+    /**
+     * `url` — URL input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/url
+     */
+    case URL = 'url';
+
+    /**
+     * `week` — Week input control (`<input>`).
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/week
+     */
+    case WEEK = 'week';
+}

--- a/tests/HasTypeTest.php
+++ b/tests/HasTypeTest.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Attribute\Tests;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use Stringable;
 use UIAwesome\Html\Attribute\HasType;
 use UIAwesome\Html\Attribute\Tests\Support\Provider\TypeProvider;
-use UIAwesome\Html\Attribute\Values\Attribute;
-use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Attribute\Values\{Attribute, Type};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Mixin\HasAttributes;
 use UnitEnum;
 
@@ -87,5 +89,24 @@ final class HasTypeTest extends TestCase
             Attributes::render($instance->getAttributes()),
             $message,
         );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingTypeValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasType;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                Attribute::TYPE->value,
+                implode("', '", Enum::normalizeArray(Type::cases())),
+            ),
+        );
+
+        $instance->type('invalid-value');
     }
 }

--- a/tests/Support/Provider/TypeProvider.php
+++ b/tests/Support/Provider/TypeProvider.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
 
+use PHPForge\Support\EnumDataProvider;
 use Stringable;
-use UIAwesome\Html\Attribute\Tests\Support\Stub\Values\Status;
+use UIAwesome\Html\Attribute\Values\{Attribute, Type};
 use UnitEnum;
 
 /**
@@ -26,6 +27,8 @@ final class TypeProvider
      */
     public static function values(): array
     {
+        $enumCases = EnumDataProvider::attributeCases(Type::class, Attribute::TYPE);
+
         $stringable = new class implements Stringable {
             public function __toString(): string
             {
@@ -33,20 +36,13 @@ final class TypeProvider
             }
         };
 
-        return [
+        $staticCases = [
             'empty string' => [
                 '',
                 [],
                 '',
                 '',
                 'Should return an empty string when setting an empty string.',
-            ],
-            'enum' => [
-                Status::ACTIVE,
-                [],
-                Status::ACTIVE,
-                ' type="active"',
-                'Should return the attribute value after setting it.',
             ],
             'null' => [
                 null,
@@ -57,16 +53,16 @@ final class TypeProvider
             ],
             'replace existing' => [
                 'text/css',
-                ['type' => 'text/plain'],
+                ['type' => 'text'],
                 'text/css',
                 ' type="text/css"',
                 "Should return new 'type' after replacing the existing 'type' attribute.",
             ],
             'string' => [
-                'text/plain',
+                'text',
                 [],
-                'text/plain',
-                ' type="text/plain"',
+                'text',
+                ' type="text"',
                 'Should return the attribute value after setting it.',
             ],
             'stringable' => [
@@ -84,5 +80,7 @@ final class TypeProvider
                 "Should unset the 'type' attribute when 'null' is provided after a value.",
             ],
         ];
+
+        return [...$staticCases, ...$enumCases];
     }
 }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive type attribute support with validation for all standard HTML type values (button, checkbox, color, date, email, password, submit, text, and more).
  * Invalid type values now trigger validation errors to ensure data integrity.

* **Tests**
  * Enhanced test coverage for type attribute validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->