### PR TITLE
feat(attribute): Add `HasMax`, `HasMin` traits and `max()`, `min()` methods to manage `max` and `min` attributes for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Enh #59: Add `HasValue` trait and `value()` method to manage `value` attribute for HTML elements (@terabytesoftw)
 - Enh #60: Add `HasForm` trait and `form()` method to manage `form` attribute for HTML elements (@terabytesoftw)
 - Enh #61: Add `Type` enum for common `type` attribute values (@terabytesoftw)
+- Enh #62: Add `HasMax`, `HasMin` traits and `max()`, `min()` methods to manage `max` and `min` attributes for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasMax.php
+++ b/src/HasMax.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `max` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `max` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `max` attribute.
+ *
+ * Key features.
+ * - Designed for use in date, time, and numeric input elements.
+ * - Handles the HTML `max` attribute for defining maximum values.
+ * - Immutable method for setting or overriding the `max` attribute.
+ * - Supports float, int, string, Stringable, UnitEnum, and `null` for flexible max assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/max
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasMax
+{
+    /**
+     * Sets the HTML `max` attribute for the element.
+     *
+     * Creates a new instance with the specified max value.
+     *
+     * The `max` attribute defines the greatest value in the range of permitted values. If the `value` entered exceeds
+     * this, the element fails constraint validation. It is valid for date, month, week, time, datetime-local, number,
+     * and range input types.
+     *
+     * For date and time inputs, the value must be a valid date/time string. For numeric inputs, the value must be a
+     * number. If the value is not a valid number, the element has no maximum value.
+     *
+     * There is a special case: if the data type is periodic (such as for dates or times), the value of `max` may be
+     * lower than the value of `min`, which indicates that the range may wrap around; for example, this allows you to
+     * specify a time range from 10 PM to 4 AM.
+     *
+     * @param float|int|string|Stringable|UnitEnum|null $value Maximum value to set for the element. Can be `null` to
+     * unset the attribute.
+     *
+     * @return static New instance with the updated `max` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->max(100);
+     * $element->max('2024-12-31');
+     * $element->max('23:59');
+     * $element->max(null);
+     * ```
+     */
+    public function max(float|int|string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::MAX, $value);
+    }
+}

--- a/src/HasMin.php
+++ b/src/HasMin.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `min` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `min` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `min` attribute.
+ *
+ * Key features.
+ * - Designed for use in date, time, and numeric input elements.
+ * - Handles the HTML `min` attribute for defining minimum values.
+ * - Immutable method for setting or overriding the `min` attribute.
+ * - Supports float, int, string, Stringable, UnitEnum, and `null` for flexible min assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/min
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasMin
+{
+    /**
+     * Sets the HTML `min` attribute for the element.
+     *
+     * Creates a new instance with the specified min value.
+     *
+     * The `min` attribute defines the most negative value in the range of permitted values. If the `value` entered is
+     * less than this, the element fails constraint validation. It is valid for date, month, week, time, datetime-local,
+     * number, and range input types, as well as meter.
+     *
+     * For date and time inputs, the value must be a valid date/time string. For numeric inputs, the value must be a
+     * number. This value must be less than or equal to the value of the `max` attribute.
+     *
+     * If the `min` attribute is present but is not specified or is invalid, no `min` value is applied. If the `min`
+     * attribute is valid and a non-empty value is less than the minimum allowed, constraint validation will prevent
+     * form submission.
+     *
+     * There is a special case: if the data type is periodic (such as for dates or times), the value of `max` may be
+     * lower than the value of `min`, which indicates that the range may wrap around; for example, this allows you to
+     * specify a time range from 10 PM to 4 AM.
+     *
+     * @param float|int|string|Stringable|UnitEnum|null $value Minimum value to set for the element. Can be `null` to
+     * unset the attribute.
+     *
+     * @return static New instance with the updated `min` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->min(0);
+     * $element->min('2024-01-01');
+     * $element->min('08:00');
+     * $element->min(null);
+     * ```
+     */
+    public function min(float|int|string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::MIN, $value);
+    }
+}

--- a/tests/HasMaxTest.php
+++ b/tests/HasMaxTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasMax;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\MaxProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasMax} trait managing the `max` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `max` attribute is not provided.
+ * - Sets the `max` HTML attribute and renders the expected output.
+ *
+ * {@see MaxProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasMaxTest extends TestCase
+{
+    public function testReturnEmptyWhenMaxAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasMax;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingMaxAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasMax;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->max(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(MaxProvider::class, 'values')]
+    public function testSetMaxAttributeValue(
+        float|int|string|null $max,
+        array $attributes,
+        float|int|string|null $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasMax;
+        };
+
+        $instance = $instance->attributes($attributes)->max($max);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::MAX, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/HasMinTest.php
+++ b/tests/HasMinTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasMin;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\MinProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasMin} trait managing the `min` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `min` attribute is not provided.
+ * - Sets the `min` HTML attribute and renders the expected output.
+ *
+ * {@see MinProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasMinTest extends TestCase
+{
+    public function testReturnEmptyWhenMinAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasMin;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingMinAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasMin;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->min(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(MinProvider::class, 'values')]
+    public function testSetMinAttributeValue(
+        float|int|string|null $min,
+        array $attributes,
+        float|int|string|null $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasMin;
+        };
+
+        $instance = $instance->attributes($attributes)->min($min);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::MIN, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/MaxProvider.php
+++ b/tests/Support/Provider/MaxProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasMaxTest} test cases.
+ *
+ * Provides representative input/output pairs for the `max` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class MaxProvider
+{
+    /**
+     * @phpstan-return array<string, array{float|int|string|null, mixed[], float|int|string|null, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'float' => [
+                3.14,
+                [],
+                3.14,
+                ' max="3.14"',
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                10,
+                [],
+                10,
+                ' max="10"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                10,
+                ['max' => 5],
+                10,
+                ' max="10"',
+                "Should return new 'max' after replacing the existing 'max' attribute.",
+            ],
+            'string' => [
+                '2024-01-01',
+                [],
+                '2024-01-01',
+                ' max="2024-01-01"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['max' => 10],
+                '',
+                '',
+                "Should unset the 'max' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}

--- a/tests/Support/Provider/MinProvider.php
+++ b/tests/Support/Provider/MinProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasMinTest} test cases.
+ *
+ * Provides representative input/output pairs for the `min` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class MinProvider
+{
+    /**
+     * @phpstan-return array<string, array{float|int|string|null, mixed[], float|int|string|null, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'float' => [
+                1.5,
+                [],
+                1.5,
+                ' min="1.5"',
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                0,
+                [],
+                0,
+                ' min="0"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                10,
+                ['min' => 5],
+                10,
+                ' min="10"',
+                "Should return new 'min' after replacing the existing 'min' attribute.",
+            ],
+            'string' => [
+                '08:00',
+                [],
+                '08:00',
+                ' min="08:00"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['min' => 10],
+                '',
+                '',
+                "Should unset the 'min' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced HasMax and HasMin traits for managing max and min HTML attributes on compatible elements (date/time and numeric inputs).
  * Added max() and min() methods using an immutable API pattern.

* **Tests**
  * Added comprehensive test coverage for HasMax and HasMin trait functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->