### PR TITLE
feat(attribute): Add `HasReadonly`, `HasStep` traits and `readonly()`, `step()` methods to manage `readonly` and `step` attributes for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Enh #60: Add `HasForm` trait and `form()` method to manage `form` attribute for HTML elements (@terabytesoftw)
 - Enh #61: Add `Type` enum for common `type` attribute values (@terabytesoftw)
 - Enh #62: Add `HasMax`, `HasMin` traits and `max()`, `min()` methods to manage `max` and `min` attributes for HTML elements (@terabytesoftw)
+- Enh #63: Add `HasReadonly`, `HasStep` traits and `readonly()`, `step()` methods to manage `readonly` and `step` attributes for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasReadonly.php
+++ b/src/HasReadonly.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use UIAwesome\Html\Attribute\Values\Attribute;
+
+/**
+ * Trait for managing the HTML `readonly` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `readonly` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `readonly` attribute.
+ *
+ * Key features.
+ * - Designed for use in form control elements (input, textarea).
+ * - Handles the HTML `readonly` attribute for preventing user editing.
+ * - Immutable method for setting or overriding the `readonly` attribute.
+ * - Supports bool and `null` for flexible readonly state assignment.
+ *
+ * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/readonly
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasReadonly
+{
+    /**
+     * Sets the HTML `readonly` attribute for the element.
+     *
+     * Creates a new instance with the specified readonly state.
+     *
+     * The `readonly` attribute is a boolean attribute that indicates the user should not be able to edit the value of
+     * the input. Unlike `disabled`, a readonly input is still focusable, can be tabbed to, and its value is submitted
+     * with the form.
+     *
+     * It is supported by text, search, url, tel, email, date, month, week, time, datetime-local, number, and password
+     * input types, as well as textarea. It is not applicable to hidden, range, color, checkbox, radio, or button types.
+     *
+     * The user can still select and copy text from a readonly field, but cannot modify it.
+     *
+     * @param bool|null $value Readonly state to set for the element. Use `true` to make readonly, `false` to make
+     * editable. Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `readonly` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->readonly(true);
+     * $element->readonly(false);
+     * $element->readonly(null);
+     * ```
+     */
+    public function readonly(bool|null $value): static
+    {
+        return $this->addAttribute(Attribute::READONLY, $value);
+    }
+}

--- a/src/HasStep.php
+++ b/src/HasStep.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `step` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `step` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `step` attribute.
+ *
+ * Key features.
+ * - Designed for use in numeric and date/time input elements.
+ * - Handles the HTML `step` attribute for defining value granularity.
+ * - Immutable method for setting or overriding the `step` attribute.
+ * - Supports float, int, string, Stringable, UnitEnum, and `null` for flexible step assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/step
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasStep
+{
+    /**
+     * Sets the HTML `step` attribute for the element.
+     *
+     * Creates a new instance with the specified step value.
+     *
+     * The `step` attribute specifies the granularity that the value must adhere to. Only values which are a whole
+     * number of steps from the step base are valid. The step base is `min` if specified, `value` otherwise, or `0` if
+     * neither is provided (except for week, which has a default step base representing the start of week 1970-W01).
+     *
+     * It is valid for date, month, week, time, datetime-local, number, and range input types.
+     *
+     * If not explicitly included.
+     * - `step` defaults to `1` for `number` and `range`.
+     * - Each date/time input type has a default `step` value appropriate for the type.
+     *
+     * The value must be a positive number (integer or float) or the special value `any`, which means no stepping is
+     * implied and any value is allowed (barring other constraints like `min` and `max`).
+     *
+     * When the data entered doesn't adhere to the stepping configuration, the value is considered invalid in
+     * constraint validation and will match the `:invalid` pseudoclass.
+     *
+     * @param float|int|string|Stringable|UnitEnum|null $value Step value to set for the element. Use `any` for no
+     * stepping restriction, a positive number for specific granularity. Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `step` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->step(1);
+     * $element->step(0.5);
+     * $element->step('any');
+     * $element->step(null);
+     * ```
+     */
+    public function step(float|int|string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::STEP, $value);
+    }
+}

--- a/tests/HasReadonlyTest.php
+++ b/tests/HasReadonlyTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasReadonly;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\ReadonlyProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasReadonly} trait managing the `readonly` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `readonly` attribute is not provided.
+ * - Sets the `readonly` HTML attribute and renders the expected output.
+ *
+ * {@see ReadonlyProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasReadonlyTest extends TestCase
+{
+    public function testReturnEmptyWhenReadonlyAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasReadonly;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingReadonlyAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasReadonly;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->readonly(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(ReadonlyProvider::class, 'values')]
+    public function testSetReadonlyAttributeValue(
+        bool|null $readonly,
+        array $attributes,
+        bool|string|null $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasReadonly;
+        };
+
+        $instance = $instance->attributes($attributes)->readonly($readonly);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::READONLY, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/HasStepTest.php
+++ b/tests/HasStepTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasStep;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\StepProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasStep} trait managing the `step` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `step` attribute is not provided.
+ * - Sets the `step` HTML attribute and renders the expected output.
+ *
+ * {@see StepProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasStepTest extends TestCase
+{
+    public function testReturnEmptyWhenStepAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasStep;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingStepAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasStep;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->step(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(StepProvider::class, 'values')]
+    public function testSetStepAttributeValue(
+        float|int|string|Stringable|null $step,
+        array $attributes,
+        float|int|string|Stringable|null $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasStep;
+        };
+
+        $instance = $instance->attributes($attributes)->step($step);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::STEP, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/ReadonlyProvider.php
+++ b/tests/Support/Provider/ReadonlyProvider.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasReadonlyTest} test cases.
+ *
+ * Provides representative input/output pairs for the `readonly` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ReadonlyProvider
+{
+    /**
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|string|null, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'boolean false' => [
+                false,
+                [],
+                false,
+                '',
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                true,
+                [],
+                true,
+                ' readonly',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                true,
+                ['readonly' => false],
+                true,
+                ' readonly',
+                "Should return new 'readonly' after replacing the existing 'readonly' attribute.",
+            ],
+            'unset with null' => [
+                null,
+                ['readonly' => true],
+                '',
+                '',
+                "Should unset the 'readonly' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}

--- a/tests/Support/Provider/StepProvider.php
+++ b/tests/Support/Provider/StepProvider.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use Stringable;
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasStepTest} test cases.
+ *
+ * Provides representative input/output pairs for the `step` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class StepProvider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{float|int|string|Stringable|UnitEnum|null, mixed[], float|int|string|Stringable|UnitEnum, string, string},
+     * >
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'any';
+            }
+        };
+
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'float' => [
+                0.5,
+                [],
+                0.5,
+                ' step="0.5"',
+                'Should return the attribute value after setting it.',
+            ],
+            'integer' => [
+                1,
+                [],
+                1,
+                ' step="1"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                1,
+                ['step' => 0.5],
+                1,
+                ' step="1"',
+                "Should return new 'step' after replacing the existing 'step' attribute.",
+            ],
+            'string' => [
+                'any',
+                [],
+                'any',
+                ' step="any"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' step="any"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['step' => 1],
+                '',
+                '',
+                "Should unset the 'step' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new traits for managing HTML readonly and step attributes with fluent, immutable APIs.

* **Tests**
  * Comprehensive test coverage added for both new traits, including multiple test scenarios and data providers.

* **Documentation**
  * Updated changelog with enhancements related to readonly and step attribute management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->