### PR TITLE
feat(attribute): Add `HasMaxlength`, `HasMinlength` traits and `maxlength()`, `minlength()` methods to manage `maxlength` and `minlength` attributes for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Enh #61: Add `Type` enum for common `type` attribute values (@terabytesoftw)
 - Enh #62: Add `HasMax`, `HasMin` traits and `max()`, `min()` methods to manage `max` and `min` attributes for HTML elements (@terabytesoftw)
 - Enh #63: Add `HasReadonly`, `HasStep` traits and `readonly()`, `step()` methods to manage `readonly` and `step` attributes for HTML elements (@terabytesoftw)
+- Enh #64: Add `HasMaxlength`, `HasMinlength` traits and `maxlength()`, `minlength()` methods to manage `maxlength` and `minlength` attributes for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasMaxlength.php
+++ b/src/HasMaxlength.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use InvalidArgumentException;
+use Stringable;
+use UIAwesome\Html\Attribute\Exception\Message;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Validator;
+
+/**
+ * Trait for managing the HTML `maxlength` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `maxlength` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `maxlength` attribute.
+ *
+ * Key features.
+ * - Designed for use in text input and textarea elements.
+ * - Handles the HTML `maxlength` attribute for limiting character input.
+ * - Immutable method for setting or overriding the `maxlength` attribute.
+ * - Supports int and `null` for flexible maxlength assignment.
+ *
+ * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/maxlength
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasMaxlength
+{
+    /**
+     * Sets the HTML `maxlength` attribute for the element.
+     *
+     * Creates a new instance with the specified maxlength value.
+     *
+     * The `maxlength` attribute defines the maximum string length (measured in UTF-16 code units) that the user can
+     * enter into the field. This must be an integer value of 0 or higher. If no `maxlength` is specified, or an invalid
+     * value is specified, the field has no maximum length.
+     *
+     * It is valid for text, search, url, tel, email, and password input types, as well as textarea. The input will fail
+     * constraint validation if the length of the text entered exceeds `maxlength` UTF-16 code units.
+     *
+     * By default, browsers prevent users from entering more characters than allowed by the `maxlength` attribute.
+     *
+     * This value must be greater than or equal to the value of `minlength`.
+     *
+     * @param int|string|Stringable|null $value Maximum length (number of characters) to set for the element. Must be 0
+     * or higher. Can be `null` to unset the attribute.
+     *
+     * @throws InvalidArgumentException if the value is not a valid integer or string representation of an `value >= 0`.
+     *
+     * @return static New instance with the updated `maxlength` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->maxlength(50);
+     * $element->maxlength(255);
+     * $element->maxlength(null);
+     * ```
+     */
+    public function maxlength(int|string|Stringable|null $value): static
+    {
+        if ($value !== null && Validator::intLike($value) === false) {
+            throw new InvalidArgumentException(
+                Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                    (string) $value,
+                    Attribute::MAXLENGTH->value,
+                    'value >= 0',
+                ),
+            );
+        }
+
+        return $this->addAttribute(Attribute::MAXLENGTH, $value);
+    }
+}

--- a/src/HasMinlength.php
+++ b/src/HasMinlength.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use InvalidArgumentException;
+use Stringable;
+use UIAwesome\Html\Attribute\Exception\Message;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Validator;
+
+/**
+ * Trait for managing the HTML `minlength` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `minlength` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `minlength` attribute.
+ *
+ * Key features.
+ * - Designed for use in text input and textarea elements.
+ * - Handles the HTML `minlength` attribute for minimum character requirements.
+ * - Immutable method for setting or overriding the `minlength` attribute.
+ * - Supports int and `null` for flexible minlength assignment.
+ *
+ * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/minlength
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasMinlength
+{
+    /**
+     * Sets the HTML `minlength` attribute for the element.
+     *
+     * Creates a new instance with the specified minlength value.
+     *
+     * The `minlength` attribute defines the minimum string length (measured in UTF-16 code units) that the user can
+     * enter into the entry field. This must be a non-negative integer value smaller than or equal to the value
+     * specified by `maxlength`. If no `minlength` is specified, or an invalid value is specified, the input has no
+     * minimum length.
+     *
+     * It is valid for text, search, url, tel, email, and password input types, as well as textarea. The input will fail
+     * constraint validation if the length of the text entered is fewer than `minlength` UTF-16 code units, preventing
+     * form submission.
+     *
+     * Constraint validation is only applied when the value is changed by the user.
+     *
+     * @param int|string|Stringable|null $value Minimum length (number of characters) to set for the element. Must be 0
+     * or higher. Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `minlength` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->minlength(3);
+     * $element->minlength(8);
+     * $element->minlength(null);
+     * ```
+     */
+    public function minlength(int|string|Stringable|null $value): static
+    {
+        if ($value !== null && Validator::intLike($value) === false) {
+            throw new InvalidArgumentException(
+                Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                    (string) $value,
+                    Attribute::MINLENGTH->value,
+                    'value >= 0',
+                ),
+            );
+        }
+
+        return $this->addAttribute(Attribute::MINLENGTH, $value);
+    }
+}

--- a/src/HasMinlength.php
+++ b/src/HasMinlength.php
@@ -52,6 +52,8 @@ trait HasMinlength
      * @param int|string|Stringable|null $value Minimum length (number of characters) to set for the element. Must be 0
      * or higher. Can be `null` to unset the attribute.
      *
+     * @throws InvalidArgumentException if the value is not a valid integer or string representation of an `value >= 0`.
+     *
      * @return static New instance with the updated `minlength` attribute.
      *
      * Usage example:

--- a/tests/HasMaxlengthTest.php
+++ b/tests/HasMaxlengthTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\Exception\Message;
+use UIAwesome\Html\Attribute\HasMaxlength;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\MaxlengthProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasMaxlength} trait managing the `maxlength` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `maxlength` attribute is not provided.
+ * - Sets the `maxlength` HTML attribute and renders the expected output.
+ *
+ * {@see MaxlengthProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasMaxlengthTest extends TestCase
+{
+    public function testReturnEmptyWhenMaxlengthAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasMaxlength;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingMaxlengthAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasMaxlength;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->maxlength(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(MaxlengthProvider::class, 'values')]
+    public function testSetMaxlengthAttributeValue(
+        int|string|Stringable|null $maxlength,
+        array $attributes,
+        int|string|Stringable|null $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasMaxlength;
+        };
+
+        $instance = $instance->attributes($attributes)->maxlength($maxlength);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::MAXLENGTH, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    #[DataProviderExternal(MaxlengthProvider::class, 'invalidValues')]
+    public function testThrowInvalidArgumentExceptionForSettingInvalidMaxlengthAttribute(
+        int|string|Stringable $maxlength,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasMaxlength;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                (string) $maxlength,
+                Attribute::MAXLENGTH->value,
+                'value >= 0',
+            ),
+        );
+
+        $instance->maxlength($maxlength);
+    }
+}

--- a/tests/HasMinlengthTest.php
+++ b/tests/HasMinlengthTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\Exception\Message;
+use UIAwesome\Html\Attribute\HasMinlength;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\MinlengthProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasMinlength} trait managing the `minlength` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `minlength` attribute is not provided.
+ * - Sets the `minlength` HTML attribute and renders the expected output.
+ *
+ * {@see MinlengthProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasMinlengthTest extends TestCase
+{
+    public function testReturnEmptyWhenMinlengthAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasMinlength;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingMinlengthAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasMinlength;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->minlength(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(MinlengthProvider::class, 'values')]
+    public function testSetMinlengthAttributeValue(
+        int|string|Stringable|null $minlength,
+        array $attributes,
+        int|string|Stringable|null $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasMinlength;
+        };
+
+        $instance = $instance->attributes($attributes)->minlength($minlength);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::MINLENGTH, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    #[DataProviderExternal(MinlengthProvider::class, 'invalidValues')]
+    public function testThrowInvalidArgumentExceptionForSettingInvalidMinlengthAttribute(
+        int|string|Stringable $minlength,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasMinlength;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                (string) $minlength,
+                Attribute::MINLENGTH->value,
+                'value >= 0',
+            ),
+        );
+
+        $instance->minlength($minlength);
+    }
+}

--- a/tests/Support/Provider/MaxlengthProvider.php
+++ b/tests/Support/Provider/MaxlengthProvider.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use Stringable;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasMaxlengthTest} test cases.
+ *
+ * Provides representative input/output pairs for the `maxlength` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class MaxlengthProvider
+{
+    /**
+     * @phpstan-return array<string, array{int|string|Stringable}>
+     */
+    public static function invalidValues(): array
+    {
+        return [
+            'integer negative less than -1' => [
+                -2,
+            ],
+            'string float' => [
+                '5.5',
+            ],
+            'string negative less than -1' => [
+                '-2',
+            ],
+            'string non-numeric' => [
+                'invalid',
+            ],
+            'stringable negative less than -1' => [
+                new class implements Stringable {
+                    public function __toString(): string
+                    {
+                        return '-10';
+                    }
+                },
+            ],
+        ];
+    }
+
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{int|string|Stringable|null, mixed[], int|string|Stringable|null, string, string},
+     * >
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return '150';
+            }
+        };
+
+        return [
+            'integer' => [
+                50,
+                [],
+                50,
+                ' maxlength="50"',
+                'Should return the attribute value after setting it.',
+            ],
+            'integer zero' => [
+                0,
+                [],
+                0,
+                ' maxlength="0"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                50,
+                ['maxlength' => 100],
+                50,
+                ' maxlength="50"',
+                "Should return new 'maxlength' after replacing the existing 'maxlength' attribute.",
+            ],
+            'string' => [
+                '150',
+                [],
+                '150',
+                ' maxlength="150"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string zero' => [
+                '0',
+                [],
+                '0',
+                ' maxlength="0"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' maxlength="150"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['maxlength' => 50],
+                '',
+                '',
+                "Should unset the 'maxlength' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}

--- a/tests/Support/Provider/MaxlengthProvider.php
+++ b/tests/Support/Provider/MaxlengthProvider.php
@@ -23,13 +23,13 @@ final class MaxlengthProvider
     {
         return [
             'integer negative less than -1' => [
-                -2,
+                -1,
             ],
             'string float' => [
                 '5.5',
             ],
             'string negative less than -1' => [
-                '-2',
+                '-1',
             ],
             'string non-numeric' => [
                 'invalid',

--- a/tests/Support/Provider/MinlengthProvider.php
+++ b/tests/Support/Provider/MinlengthProvider.php
@@ -23,13 +23,13 @@ final class MinlengthProvider
     {
         return [
             'integer negative less than -1' => [
-                -2,
+                -1,
             ],
             'string float' => [
                 '5.5',
             ],
             'string negative less than -1' => [
-                '-2',
+                '-1',
             ],
             'string non-numeric' => [
                 'invalid',

--- a/tests/Support/Provider/MinlengthProvider.php
+++ b/tests/Support/Provider/MinlengthProvider.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use Stringable;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasMinlengthTest} test cases.
+ *
+ * Provides representative input/output pairs for the `minlength` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class MinlengthProvider
+{
+    /**
+     * @phpstan-return array<string, array{int|string|Stringable}>
+     */
+    public static function invalidValues(): array
+    {
+        return [
+            'integer negative less than -1' => [
+                -2,
+            ],
+            'string float' => [
+                '5.5',
+            ],
+            'string negative less than -1' => [
+                '-2',
+            ],
+            'string non-numeric' => [
+                'invalid',
+            ],
+            'stringable negative less than -1' => [
+                new class implements Stringable {
+                    public function __toString(): string
+                    {
+                        return '-10';
+                    }
+                },
+            ],
+        ];
+    }
+
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{int|string|Stringable|null, mixed[], int|string|Stringable|null, string, string},
+     * >
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return '150';
+            }
+        };
+
+        return [
+            'integer' => [
+                50,
+                [],
+                50,
+                ' minlength="50"',
+                'Should return the attribute value after setting it.',
+            ],
+            'integer zero' => [
+                0,
+                [],
+                0,
+                ' minlength="0"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                10,
+                ['minlength' => 5],
+                10,
+                ' minlength="10"',
+                "Should return new 'minlength' after replacing the existing 'minlength' attribute.",
+            ],
+            'string' => [
+                '150',
+                [],
+                '150',
+                ' minlength="150"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string zero' => [
+                '0',
+                [],
+                '0',
+                ' minlength="0"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' minlength="150"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['minlength' => 8],
+                '',
+                '',
+                "Should unset the 'minlength' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added immutable support for managing HTML maxlength and minlength attributes with built-in validation.

* **Tests**
  * Added comprehensive unit tests covering immutability, validation, and rendered output for maxlength and minlength behaviors.

* **Documentation**
  * Updated changelog with the new maxlength/minlength entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->