### PR TITLE
feat(attribute): Add `HasRequired` trait and `required()` method to manage `required` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Enh #62: Add `HasMax`, `HasMin` traits and `max()`, `min()` methods to manage `max` and `min` attributes for HTML elements (@terabytesoftw)
 - Enh #63: Add `HasReadonly`, `HasStep` traits and `readonly()`, `step()` methods to manage `readonly` and `step` attributes for HTML elements (@terabytesoftw)
 - Enh #64: Add `HasMaxlength`, `HasMinlength` traits and `maxlength()`, `minlength()` methods to manage `maxlength` and `minlength` attributes for HTML elements (@terabytesoftw)
+- Enh #65: Add `HasRequired` trait and `required()` method to manage `required` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasRequired.php
+++ b/src/HasRequired.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use UIAwesome\Html\Attribute\Values\Attribute;
+
+/**
+ * Trait for managing the HTML `required` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `required` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `required` attribute.
+ *
+ * Key features.
+ * - Designed for use in form control elements (input, select, textarea).
+ * - Handles the HTML `required` attribute for mandatory field validation.
+ * - Immutable method for setting or overriding the `required` attribute.
+ * - Supports bool and `null` for flexible required state assignment.
+ *
+ * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/required
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasRequired
+{
+    /**
+     * Sets the HTML `required` attribute for the element.
+     *
+     * Creates a new instance with the specified required state.
+     *
+     * The `required` attribute is a boolean attribute that indicates the user must specify a value for the input before
+     * the owning form can be submitted. If the field has no value or an invalid value, constraint validation will
+     * prevent form submission and the browser will display an error message.
+     *
+     * It is supported by text, search, url, tel, email, date, month, week, time, datetime-local, number, password,
+     * checkbox, radio, and file input types, as well as select and textarea.
+     *
+     * It is not valid for hidden, range, color, or button types.
+     *
+     * For checkboxes, the checkbox must be checked. For radio buttons, one radio button in the group must be selected.
+     *
+     * For file inputs, a file must be selected. For other types, a non-empty value must be entered.
+     *
+     * @param bool|null $value Required state to set for the element. Use `true` to require a value, `false` to make it
+     * optional. Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `required` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->required(true);
+     * $element->required(false);
+     * $element->required(null);
+     * ```
+     */
+    public function required(bool|null $value): static
+    {
+        return $this->addAttribute(Attribute::REQUIRED, $value);
+    }
+}

--- a/tests/HasRequiredTest.php
+++ b/tests/HasRequiredTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasRequired;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\RequiredProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasRequired} trait managing the `required` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `required` attribute is not provided.
+ * - Sets the `required` HTML attribute and renders the expected output.
+ *
+ * {@see RequiredProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasRequiredTest extends TestCase
+{
+    public function testReturnEmptyWhenRequiredAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasRequired;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingRequiredAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasRequired;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->required(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(RequiredProvider::class, 'values')]
+    public function testSetRequiredAttributeValue(
+        bool|null $required,
+        array $attributes,
+        bool|null $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasRequired;
+        };
+
+        $instance = $instance->attributes($attributes)->required($required);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::REQUIRED, null),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/RequiredProvider.php
+++ b/tests/Support/Provider/RequiredProvider.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasRequiredTest} test cases.
+ *
+ * Provides representative input/output pairs for the `required` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class RequiredProvider
+{
+    /**
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|null, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'boolean false' => [
+                false,
+                [],
+                false,
+                '',
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                true,
+                [],
+                true,
+                ' required',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                null,
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                true,
+                ['required' => false],
+                true,
+                ' required',
+                "Should return new 'required' after replacing the existing 'required' attribute.",
+            ],
+            'unset with null' => [
+                null,
+                ['required' => true],
+                null,
+                '',
+                "Should unset the 'required' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing the HTML `required` attribute on form elements. Developers can now easily set, update, or remove the required attribute from input fields and form components.

* **Tests**
  * Comprehensive unit tests added to validate required attribute handling across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->