### PR TITLE
feat(attribute): Add `HasAccept`, `HasAutocomplete` traits and `accept()`, `autocomplete()` methods to manage `accept` and `autocomplete` attributes for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Enh #64: Add `HasMaxlength`, `HasMinlength` traits and `maxlength()`, `minlength()` methods to manage `maxlength` and `minlength` attributes for HTML elements (@terabytesoftw)
 - Enh #65: Add `HasRequired` trait and `required()` method to manage `required` attribute for HTML elements (@terabytesoftw)
 - Bug #66: Enhance HTML attribute element handling with Stringable and UnitEnum support (@terabytesoftw)
+- Enh #67: Add `HasAccept`, `HasAutocomplete` traits and `accept()`, `autocomplete()` methods to manage `accept` and `autocomplete` attributes for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasAccept.php
+++ b/src/HasAccept.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `accept` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `accept` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `accept` attribute.
+ *
+ * Key features.
+ * - Designed for use in file input elements.
+ * - Handles the HTML `accept` attribute for defining acceptable file types.
+ * - Immutable method for setting or overriding the `accept` attribute.
+ * - Supports `string`, `Stringable`, `UnitEnum`, and `null` for flexible file type assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/accept
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasAccept
+{
+    /**
+     * Sets the HTML `accept` attribute for the element.
+     *
+     * Creates a new instance with the specified accept value.
+     *
+     * The `accept` attribute defines the file types the server accepts. It is valid for `file` input types only.
+     *
+     * The value is a comma-separated list of unique content type specifiers, which can include.
+     * - A file extension starting with a period (for example, `.jpg`, `.pdf`)
+     * - A valid MIME type with no extensions (for example, `image/jpeg`, `application/pdf`)
+     * - `audio/*`, `video/*`, or `image/*` representing all audio, video, or image types
+     *
+     * @param string|Stringable|UnitEnum|null $value Accept value to set for the element. Can be `null` to unset the
+     * attribute.
+     *
+     * @return static New instance with the updated `accept` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->accept('image/*');
+     * $element->accept('.jpg,.png,.pdf');
+     * $element->accept('image/jpeg,application/pdf');
+     * $element->accept(null);
+     * ```
+     */
+    public function accept(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::ACCEPT, $value);
+    }
+}

--- a/src/HasAutocomplete.php
+++ b/src/HasAutocomplete.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `autocomplete` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `autocomplete` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `autocomplete` attribute.
+ *
+ * Key features.
+ * - Designed for use in form control elements (input, textarea, select).
+ * - Handles the HTML `autocomplete` attribute for autofill functionality.
+ * - Immutable method for setting or overriding the `autocomplete` attribute.
+ * - Supports `string`, `Stringable`, `UnitEnum`, and `null` for flexible autocomplete assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasAutocomplete
+{
+    /**
+     * Sets the HTML `autocomplete` attribute for the element.
+     *
+     * Creates a new instance with the specified autocomplete value.
+     *
+     * The `autocomplete` attribute provides a hint to browsers for autofill functionality. It is valid for `<hidden>`,
+     * `<text>`, `<search>`, `<url>`, `<tel>`, `<email>`, `<date>`, `<month>`, `<week>`, `<time>`, `<datetime-local>`,
+     * `<number>`, `<range>`, `<color>`, and `<password>` input types.
+     *
+     * It has no effect on `<checkbox>`, `<radio>`, `<file>`, or button types.
+     *
+     * Common values include:
+     * - `on` or `off` to enable/disable autocomplete
+     * - `name`, `email`, `tel`, `address-line1` for contact information
+     * - `username`, `new-password`, `current-password` for credentials
+     * - `organization`, `street-address`, `postal-code` for addresses
+     *
+     * @param string|Stringable|UnitEnum|null $value Autocomplete value to set for the element. Can be `null` to unset
+     * the attribute.
+     *
+     * @return static New instance with the updated `autocomplete` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->autocomplete('on');
+     * $element->autocomplete('email');
+     * $element->autocomplete('new-password');
+     * $element->autocomplete(null);
+     * ```
+     */
+    public function autocomplete(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::AUTOCOMPLETE, $value);
+    }
+}

--- a/tests/HasAcceptTest.php
+++ b/tests/HasAcceptTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasAccept;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\AcceptProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasAccept} trait managing the `accept` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `accept` attribute is not provided.
+ * - Sets the `accept` HTML attribute and renders the expected output.
+ *
+ * {@see AcceptProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasAcceptTest extends TestCase
+{
+    public function testReturnEmptyWhenAcceptAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAccept;
+            use HasAttributes;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingAcceptAttribute(): void
+    {
+        $instance = new class {
+            use HasAccept;
+            use HasAttributes;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->accept(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(AcceptProvider::class, 'values')]
+    public function testSetAcceptAttributeValue(
+        string|Stringable|UnitEnum|null $accept,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAccept;
+            use HasAttributes;
+        };
+
+        $instance = $instance->attributes($attributes)->accept($accept);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::ACCEPT, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/HasAutocompleteTest.php
+++ b/tests/HasAutocompleteTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasAutocomplete;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\AutocompleteProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasAutocomplete} trait managing the `autocomplete` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `autocomplete` attribute is not provided.
+ * - Sets the `autocomplete` HTML attribute and renders the expected output.
+ *
+ * {@see AutocompleteProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasAutocompleteTest extends TestCase
+{
+    public function testReturnEmptyWhenAutocompleteAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasAutocomplete;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingAutocompleteAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasAutocomplete;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->autocomplete(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(AutocompleteProvider::class, 'values')]
+    public function testSetAutocompleteAttributeValue(
+        string|Stringable|UnitEnum|null $autocomplete,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasAutocomplete;
+        };
+
+        $instance = $instance->attributes($attributes)->autocomplete($autocomplete);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::AUTOCOMPLETE, null),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/HasAutocompleteTest.php
+++ b/tests/HasAutocompleteTest.php
@@ -79,7 +79,7 @@ final class HasAutocompleteTest extends TestCase
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(Attribute::AUTOCOMPLETE, null),
+            $instance->getAttribute(Attribute::AUTOCOMPLETE, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Support/Provider/AcceptProvider.php
+++ b/tests/Support/Provider/AcceptProvider.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Tests\Support\Stub\Values\{Backed, Unit};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasAcceptTest} test cases.
+ *
+ * Provides representative input/output pairs for the `accept` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class AcceptProvider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{string|Stringable|UnitEnum|null, mixed[], string|Stringable|UnitEnum, string, string},
+     * >
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'image/*';
+            }
+        };
+
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'enum backed' => [
+                Backed::VALUE,
+                [],
+                Backed::VALUE,
+                ' accept="value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'enum unit' => [
+                Unit::value,
+                [],
+                Unit::value,
+                ' accept="value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'image/*',
+                ['accept' => '.pdf'],
+                'image/*',
+                ' accept="image/*"',
+                "Should return new 'accept' after replacing the existing 'accept' attribute.",
+            ],
+            'string' => [
+                '.pdf',
+                [],
+                '.pdf',
+                ' accept=".pdf"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' accept="image/*"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['accept' => 'image/*'],
+                '',
+                '',
+                "Should unset the 'accept' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}

--- a/tests/Support/Provider/AutocompleteProvider.php
+++ b/tests/Support/Provider/AutocompleteProvider.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Tests\Support\Stub\Values\{Backed, Unit};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasAutocompleteTest} test cases.
+ *
+ * Provides representative input/output pairs for the `autocomplete` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class AutocompleteProvider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{string|Stringable|UnitEnum|null, mixed[], string|Stringable|UnitEnum, string, string},
+     * >
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'email';
+            }
+        };
+
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'enum backed' => [
+                Backed::VALUE,
+                [],
+                Backed::VALUE,
+                ' autocomplete="value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'enum unit' => [
+                Unit::value,
+                [],
+                Unit::value,
+                ' autocomplete="value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'on',
+                ['autocomplete' => 'email'],
+                'on',
+                ' autocomplete="on"',
+                "Should return new 'autocomplete' after replacing the existing 'autocomplete' attribute.",
+            ],
+            'string' => [
+                'on',
+                [],
+                'on',
+                ' autocomplete="on"',
+                'Should return the attribute value after setting it to on.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' autocomplete="email"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['autocomplete' => 'on'],
+                '',
+                '',
+                "Should unset the 'autocomplete' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added capabilities to manage HTML accept attributes on form elements with an immutable API.
  * Added capabilities to manage HTML autocomplete attributes on form controls with an immutable API.
  * Support for string, Stringable, and enum-backed attribute values.

* **Tests**
  * Comprehensive test coverage validates immutability, attribute storage, and HTML rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->