### PR TITLE
feat(attribute): Add `HasChecked`, `HasDirname` traits and `checked()`, `dirname()` methods to manage `checked` and `dirname` attributes for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Enh #65: Add `HasRequired` trait and `required()` method to manage `required` attribute for HTML elements (@terabytesoftw)
 - Bug #66: Enhance HTML attribute element handling with Stringable and UnitEnum support (@terabytesoftw)
 - Enh #67: Add `HasAccept`, `HasAutocomplete` traits and `accept()`, `autocomplete()` methods to manage `accept` and `autocomplete` attributes for HTML elements (@terabytesoftw)
+- Enh #68: Add `HasChecked`, `HasDirname` traits and `checked()`, `dirname()` methods to manage `checked` and `dirname` attributes for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasChecked.php
+++ b/src/HasChecked.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use UIAwesome\Html\Attribute\Values\Attribute;
+
+/**
+ * Trait for managing the HTML `checked` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `checked` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `checked` attribute.
+ *
+ * Key features.
+ * - Designed for use in checkbox and radio input elements.
+ * - Handles the HTML `checked` attribute for indicating selection state.
+ * - Immutable method for setting or overriding the `checked` attribute.
+ * - Supports `bool` and `null` for flexible checked state assignment.
+ *
+ * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/checked
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasChecked
+{
+    /**
+     * Sets the HTML `checked` attribute for the element.
+     *
+     * Creates a new instance with the specified checked state.
+     *
+     * The `checked` attribute is a boolean attribute that indicates whether the control is checked. It is valid for
+     * `<checkbox>` and `<radio>` input types only. For radio buttons, only one button in a group with the same `name`
+     * can be checked at a time.
+     *
+     * When a checkbox or radio button is checked, its `name` and `value` are submitted with the form. If not checked,
+     * the value is not submitted. The default value for checkboxes and radio buttons when checked is `on`.
+     *
+     * @param bool|null $value Checked state to set for the element. Use `true` to check, `false` to uncheck. Can be
+     * `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `checked` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->checked(true);
+     * $element->checked(false);
+     * $element->checked(null);
+     * ```
+     */
+    public function checked(bool|null $value): static
+    {
+        return $this->addAttribute(Attribute::CHECKED, $value);
+    }
+}

--- a/src/HasDirname.php
+++ b/src/HasDirname.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `dirname` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `dirname` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `dirname` attribute.
+ *
+ * Key features.
+ * - Designed for use in input and textarea elements with text content.
+ * - Handles the HTML `dirname` attribute for submitting text directionality.
+ * - Immutable method for setting or overriding the `dirname` attribute.
+ * - Supports `string`, `Stringable`, `UnitEnum`, and `null` for flexible dirname assignment.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/dirname
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasDirname
+{
+    /**
+     * Sets the HTML `dirname` attribute for the element.
+     *
+     * Creates a new instance with the specified dirname value.
+     *
+     * The `dirname` attribute enables submission of the element's directionality. When included, the form control will
+     * submit with two name/value pairs: the first being the `name` and `value`, and the second being the value of the
+     * `dirname` attribute as the name, with a value of `ltr` (left-to-right) or `rtl` (right-to-left) as set by the
+     * browser.
+     *
+     * It is valid for `<hidden>`, `<text>`, `<search>`, `<url>`, `<tel>`, and `<email>` input types.
+     *
+     * For example, if you have `<input type="text" name="comment" dirname="comment-dir">`, submitting the form will
+     * include both `comment=...` and `comment-dir=ltr` (or `rtl`).
+     *
+     * @param string|Stringable|UnitEnum|null $value Dirname value to set for the element. This becomes the name of the
+     * submitted directionality field. Can be `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `dirname` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->dirname('comment-dir');
+     * $element->dirname('text-direction');
+     * $element->dirname(null);
+     * ```
+     */
+    public function dirname(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::DIRNAME, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -65,6 +65,13 @@ enum Attribute: string
     case CHARSET = 'charset';
 
     /**
+     * `checked` — Indicates whether the command or control is checked.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/checked
+     */
+    case CHECKED = 'checked';
+
+    /**
      * `content` — A value associated with a meta element.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/content

--- a/tests/HasCheckedTest.php
+++ b/tests/HasCheckedTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasChecked;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\CheckedProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasChecked} trait managing the `checked` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `checked` attribute is not provided.
+ * - Sets the `checked` HTML attribute and renders the expected output.
+ *
+ * {@see CheckedProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasCheckedTest extends TestCase
+{
+    public function testReturnEmptyWhenCheckedAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasChecked;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingCheckedAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasChecked;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->checked(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(CheckedProvider::class, 'values')]
+    public function testSetCheckedAttributeValue(
+        bool|null $checked,
+        array $attributes,
+        bool|string $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasChecked;
+        };
+
+        $instance = $instance->attributes($attributes)->checked($checked);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::CHECKED, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/HasDirnameTest.php
+++ b/tests/HasDirnameTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasDirname;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\DirnameProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasDirname} trait managing the `dirname` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `dirname` attribute is not provided.
+ * - Sets the `dirname` HTML attribute and renders the expected output.
+ *
+ * {@see DirnameProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasDirnameTest extends TestCase
+{
+    public function testReturnEmptyWhenDirnameAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasDirname;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingDirnameAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasDirname;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->dirname(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(DirnameProvider::class, 'values')]
+    public function testSetDirnameAttributeValue(
+        string|Stringable|UnitEnum|null $dirname,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasDirname;
+        };
+
+        $instance = $instance->attributes($attributes)->dirname($dirname);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::DIRNAME, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/CheckedProvider.php
+++ b/tests/Support/Provider/CheckedProvider.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasCheckedTest} test cases.
+ *
+ * Provides representative input/output pairs for the `checked` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class CheckedProvider
+{
+    /**
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|string, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'boolean false' => [
+                false,
+                [],
+                false,
+                '',
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                true,
+                [],
+                true,
+                ' checked',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                true,
+                ['checked' => false],
+                true,
+                ' checked',
+                "Should return new 'checked' after replacing the existing 'checked' attribute.",
+            ],
+            'unset with null' => [
+                null,
+                ['checked' => true],
+                '',
+                '',
+                "Should unset the 'checked' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}

--- a/tests/Support/Provider/DirnameProvider.php
+++ b/tests/Support/Provider/DirnameProvider.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use PHPForge\Support\Stub\{BackedString, Unit};
+use Stringable;
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasDirnameTest} test cases.
+ *
+ * Provides representative input/output pairs for the `dirname` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class DirnameProvider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{string|Stringable|UnitEnum|null, mixed[], string|Stringable|UnitEnum, string, string},
+     * >
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'comment-dir';
+            }
+        };
+
+        return [
+           'enum backed string' => [
+                BackedString::VALUE,
+                [],
+                BackedString::VALUE,
+                ' dirname="value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'enum unit' => [
+                Unit::value,
+                [],
+                Unit::value,
+                ' dirname="value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'comment-dir',
+                ['dirname' => 'text-direction'],
+                'comment-dir',
+                ' dirname="comment-dir"',
+                "Should return new 'dirname' after replacing the existing 'dirname' attribute.",
+            ],
+            'string' => [
+                'text-direction',
+                [],
+                'text-direction',
+                ' dirname="text-direction"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' dirname="comment-dir"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['dirname' => 'comment-dir'],
+                '',
+                '',
+                "Should unset the 'dirname' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}

--- a/tests/Support/Provider/DirnameProvider.php
+++ b/tests/Support/Provider/DirnameProvider.php
@@ -34,7 +34,7 @@ final class DirnameProvider
         };
 
         return [
-           'enum backed string' => [
+            'enum backed string' => [
                 BackedString::VALUE,
                 [],
                 BackedString::VALUE,


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added checked() to set/unset the HTML checked attribute on form controls.
  * Added dirname() to set/unset the HTML dirname attribute, accepting strings, stringable values, enums, or null.
  * Recognized "checked" as a supported attribute key.

* **Tests**
  * New unit tests and data providers covering checked and dirname behaviors, immutability, and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->