### PR TITLE
feat(attribute): Add `HasList`, `HasMultiple` traits and `list()`, `multiple()` methods to manage `list` and `multiple` attributes for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Bug #66: Enhance HTML attribute element handling with Stringable and UnitEnum support (@terabytesoftw)
 - Enh #67: Add `HasAccept`, `HasAutocomplete` traits and `accept()`, `autocomplete()` methods to manage `accept` and `autocomplete` attributes for HTML elements (@terabytesoftw)
 - Enh #68: Add `HasChecked`, `HasDirname` traits and `checked()`, `dirname()` methods to manage `checked` and `dirname` attributes for HTML elements (@terabytesoftw)
+- Enh #69: Add `HasList`, `HasMultiple` traits and `list()`, `multiple()` methods to manage `list` and `multiple` attributes for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasList.php
+++ b/src/HasList.php
@@ -39,10 +39,13 @@ trait HasList
      * The `list` attribute identifies a `<datalist>` element that provides a list of predefined options to suggest to
      * the user. The value must be the `id` of a `<datalist>` element in the same document.
      *
-     * It is valid on `<text>`, `<search>`, `<url>`, `<tel>`, `<email>`, `<date>`, `<month>`, `<week>`, `<time>`,
-     * `<datetime-local>`, `<number>`, `<range>`, and `<color>` input types.
+     * It is valid on `<input type="text">`, `<input type="search">`, `<input type="url">`, `<input type="tel">`,
+     * `<input type="email">`, `<input type="date">`, `<input type="month">`, `<input type="week">`,
+     * `<input type="time">`, `<input type="datetime-local">`, `<input type="number">`, `<input type="range">`, and
+     * `<input type="color">`.
      *
-     * It is not supported by `<hidden>`, `<password>`, `<checkbox>`, `<radio>`, `<file>`, or button types.
+     * It is not supported by `<input type="hidden">`, `<input type="password">`, `<input type="checkbox">`,
+     * `<input type="radio">`, `<input type="file">`, or button types.
      *
      * Values in the datalist that are not compatible with the input's `type` are not included in the suggested options.
      *

--- a/src/HasList.php
+++ b/src/HasList.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Trait for managing the HTML `list` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `list` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `list` attribute.
+ *
+ * Key features.
+ * - Designed for use in input elements to provide autocomplete suggestions.
+ * - Handles the HTML `list` attribute for associating a datalist with an input.
+ * - Immutable method for setting or overriding the `list` attribute.
+ * - Supports `string`, `Stringable`, `UnitEnum`, and `null` for flexible list association.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/list
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasList
+{
+    /**
+     * Sets the HTML `list` attribute for the element.
+     *
+     * Creates a new instance with the specified list value.
+     *
+     * The `list` attribute identifies a `<datalist>` element that provides a list of predefined options to suggest to
+     * the user. The value must be the `id` of a `<datalist>` element in the same document.
+     *
+     * It is valid on `<text>`, `<search>`, `<url>`, `<tel>`, `<email>`, `<date>`, `<month>`, `<week>`, `<time>`,
+     * `<datetime-local>`, `<number>`, `<range>`, and `<color>` input types.
+     *
+     * It is not supported by `<hidden>`, `<password>`, `<checkbox>`, `<radio>`, `<file>`, or button types.
+     *
+     * Values in the datalist that are not compatible with the input's `type` are not included in the suggested options.
+     *
+     * @param string|Stringable|UnitEnum|null $value List (datalist ID) to associate with the element. Can be `null` to
+     * unset the attribute.
+     *
+     * @return static New instance with the updated `list` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->list('suggestions');
+     * $element->list('countries-list');
+     * $element->list(null);
+     * ```
+     */
+    public function list(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(Attribute::LIST, $value);
+    }
+}

--- a/src/HasMultiple.php
+++ b/src/HasMultiple.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use UIAwesome\Html\Attribute\Values\Attribute;
+
+/**
+ * Trait for managing the HTML `multiple` attribute in tag rendering.
+ *
+ * Provides an immutable API for setting the `multiple` attribute on HTML elements.
+ *
+ * Intended for use in tags and components that require manipulation of the `multiple` attribute.
+ *
+ * Key features.
+ * - Designed for use in email, file input elements, and select elements.
+ * - Handles the HTML `multiple` attribute for allowing multiple values.
+ * - Immutable method for setting or overriding the `multiple` attribute.
+ * - Supports bool and `null` for flexible multiple state assignment.
+ *
+ * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/multiple
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasMultiple
+{
+    /**
+     * Sets the HTML `multiple` attribute for the element.
+     *
+     * Creates a new instance with the specified multiple state.
+     *
+     * The `multiple` attribute is a boolean attribute that indicates whether the user can enter or select more than one
+     * value.
+     *
+     * It is valid for `<email>` and `<file>` input types, as well as `<select>` elements.
+     * - For `<email>` inputs, when `multiple` is set, the user can enter comma-separated email addresses.
+     * - For `<file>` inputs, the user can choose more than one file.
+     * - For `<select>` elements, multiple options can be selected.
+     *
+     * When the `multiple` attribute is set on a `<file>` input, the `accept` attribute can be used to restrict the
+     * types of files that can be selected.
+     *
+     * @param bool|null $value Multiple state to set for the element. Use `true` to allow multiple values, `false` to
+     * disallow, or `null` to unset the attribute.
+     *
+     * @return static New instance with the updated `multiple` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->multiple(true);
+     * $element->multiple(false);
+     * $element->multiple(null);
+     * ```
+     */
+    public function multiple(bool|null $value): static
+    {
+        return $this->addAttribute(Attribute::MULTIPLE, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -171,6 +171,13 @@ enum Attribute: string
     case INTEGRITY = 'integrity';
 
     /**
+     * `list` — Identifies a `<datalist>` element that provides predefined options to suggest to the user.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#list
+     */
+    case LIST = 'list';
+
+    /**
      * `max` — Indicates the maximum value allowed.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/max

--- a/tests/HasListTest.php
+++ b/tests/HasListTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasList;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\ListProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasList} trait managing the `list` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `list` attribute is not provided.
+ * - Sets the `list` HTML attribute and renders the expected output.
+ *
+ * {@see ListProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasListTest extends TestCase
+{
+    public function testReturnEmptyWhenListAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasList;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingListAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasList;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->list(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(ListProvider::class, 'values')]
+    public function testSetListAttributeValue(
+        string|Stringable|UnitEnum|null $list,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasList;
+        };
+
+        $instance = $instance->attributes($attributes)->list($list);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::LIST, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/HasMultipleTest.php
+++ b/tests/HasMultipleTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\HasMultiple;
+use UIAwesome\Html\Attribute\Tests\Support\Provider\MultipleProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see HasMultiple} trait managing the `multiple` HTML attribute.
+ *
+ * Verifies rendered output, immutability, and attribute override behavior.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `multiple` attribute is not provided.
+ * - Sets the `multiple` HTML attribute and renders the expected output.
+ *
+ * {@see MultipleProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasMultipleTest extends TestCase
+{
+    public function testReturnEmptyWhenMultipleAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasMultiple;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingMultipleAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasMultiple;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->multiple(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(MultipleProvider::class, 'values')]
+    public function testSetMultipleAttributeValue(
+        bool|null $multiple,
+        array $attributes,
+        bool|string $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasMultiple;
+        };
+
+        $instance = $instance->attributes($attributes)->multiple($multiple);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::MULTIPLE, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Support/Provider/ListProvider.php
+++ b/tests/Support/Provider/ListProvider.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+use PHPForge\Support\Stub\{BackedString, Unit};
+use Stringable;
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasListTest} test cases.
+ *
+ * Provides representative input/output pairs for the `list` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ListProvider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{string|Stringable|UnitEnum|null, mixed[], string|Stringable|UnitEnum, string, string},
+     * >
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'suggestions';
+            }
+        };
+
+        return [
+            'enum backed string' => [
+                BackedString::VALUE,
+                [],
+                BackedString::VALUE,
+                ' list="value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'enum unit' => [
+                Unit::value,
+                [],
+                Unit::value,
+                ' list="value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'suggestions',
+                ['list' => 'oldList'],
+                'suggestions',
+                ' list="suggestions"',
+                "Should return new 'list' after replacing the existing 'list' attribute.",
+            ],
+            'string' => [
+                'suggestions',
+                [],
+                'suggestions',
+                ' list="suggestions"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' list="suggestions"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['list' => 'suggestions'],
+                '',
+                '',
+                "Should unset the 'list' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}

--- a/tests/Support/Provider/MultipleProvider.php
+++ b/tests/Support/Provider/MultipleProvider.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Support\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasMultipleTest} test cases.
+ *
+ * Provides representative input/output pairs for the `multiple` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class MultipleProvider
+{
+    /**
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|string, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'boolean false' => [
+                false,
+                [],
+                false,
+                '',
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                true,
+                [],
+                true,
+                ' multiple',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                true,
+                ['multiple' => false],
+                true,
+                ' multiple',
+                "Should return new 'multiple' after replacing the existing 'multiple' attribute.",
+            ],
+            'unset with null' => [
+                null,
+                ['multiple' => true],
+                '',
+                '',
+                "Should unset the 'multiple' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
