### PR TITLE
fix(attribute): Move `HasDisabled` trait to `UIAwesome\Html\Attribute` namespace and update related imports accordingly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Bug #73: Standardize PHPDoc headers across src directory files (@terabytesoftw)
 - Bug #74: Remove directory `tests\Stub` and move `tests\Support\Provider` to `tests\Provider` in tests (@terabytesoftw)
 - Bug #75: Standardize PHPDoc headers for test classes (@terabytesoftw)
+- Bug #76: Move `HasDisabled` trait to `UIAwesome\Html\Attribute` namespace and update related imports accordingly (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/HasDisabled.php
+++ b/src/HasDisabled.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace UIAwesome\Html\Attribute\Form;
+namespace UIAwesome\Html\Attribute;
 
 use UIAwesome\Html\Attribute\Values\Attribute;
 

--- a/tests/HasDisabledTest.php
+++ b/tests/HasDisabledTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace UIAwesome\Html\Attribute\Tests\Form;
+namespace UIAwesome\Html\Attribute\Tests;
 
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
-use UIAwesome\Html\Attribute\Form\HasDisabled;
-use UIAwesome\Html\Attribute\Tests\Provider\Form\DisabledProvider;
+use UIAwesome\Html\Attribute\HasDisabled;
+use UIAwesome\Html\Attribute\Tests\Provider\DisabledProvider;
 use UIAwesome\Html\Attribute\Values\Attribute;
 use UIAwesome\Html\Helper\Attributes;
 use UIAwesome\Html\Mixin\HasAttributes;

--- a/tests/Provider/DisabledProvider.php
+++ b/tests/Provider/DisabledProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace UIAwesome\Html\Attribute\Tests\Provider\Form;
+namespace UIAwesome\Html\Attribute\Tests\Provider;
 
 /**
  * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Form\HasDisabledTest} test cases.

--- a/tests/Provider/DisabledProvider.php
+++ b/tests/Provider/DisabledProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Attribute\Tests\Provider;
 
 /**
- * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Form\HasDisabledTest} test cases.
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasDisabledTest} test cases.
  *
  * Provides representative input/output pairs for the `disabled` attribute.
  *


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
