### PR TITLE
feat(attribute): Add `HasPopover`, `HasPopoverTarget`, `HasPopoverTargetAction` traits and `popover()`, `popoverTarget()`, `popoverTargetAction()` methods to manage popover attributes for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Bug #75: Standardize PHPDoc headers for test classes (@terabytesoftw)
 - Bug #76: Move `HasDisabled` trait to `UIAwesome\Html\Attribute` namespace and update related imports accordingly (@terabytesoftw)
 - Enh #77: Add `Autocomplete` enum and update `AutocompleteProvider` to add test data (@terabytesoftw)
+- Enh #78: Add `HasPopover`, `HasPopoverTarget`, `HasPopoverTargetAction` traits and `popover()`, `popoverTarget()`, `popoverTargetAction()` methods to manage popover attributes for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/Element/HasPopoverTarget.php
+++ b/src/Element/HasPopoverTarget.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Element;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\ElementAttribute;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the `popovertarget` attribute.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/popovertarget
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasPopoverTarget
+{
+    /**
+     * Sets the `popovertarget` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->popoverTarget('popover-id');
+     * $element->popoverTarget($targetId);
+     * $element->popoverTarget(null);
+     * ```
+     *
+     * @param string|Stringable|UnitEnum|null $value Popover target ID, or `null` to remove the attribute.
+     *
+     * @return static New instance with the updated `popovertarget` attribute.
+     */
+    public function popoverTarget(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute(ElementAttribute::POPOVERTARGET, $value);
+    }
+}

--- a/src/Element/HasPopoverTargetAction.php
+++ b/src/Element/HasPopoverTargetAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Attribute\Element;
 
+use InvalidArgumentException;
 use Stringable;
 use UIAwesome\Html\Attribute\Values\{ElementAttribute, PopoverTargetAction};
 use UIAwesome\Html\Helper\Validator;
@@ -34,6 +35,8 @@ trait HasPopoverTargetAction
      *
      * @param string|Stringable|UnitEnum|null $value Popover target action (`hide`, `show`, `toggle`), or `null` to
      * remove the attribute.
+     *
+     * @throws InvalidArgumentException If the provided value is not valid.
      *
      * @return static New instance with the updated `popovertargetaction` attribute.
      */

--- a/src/Element/HasPopoverTargetAction.php
+++ b/src/Element/HasPopoverTargetAction.php
@@ -32,7 +32,8 @@ trait HasPopoverTargetAction
      * $element->popoverTargetAction(null);
      * ```
      *
-     * @param string|Stringable|UnitEnum|null $value Popover target action, or `null` to remove the attribute.
+     * @param string|Stringable|UnitEnum|null $value Popover target action (`hide`, `show`, `toggle`), or `null` to
+     * remove the attribute.
      *
      * @return static New instance with the updated `popovertargetaction` attribute.
      */

--- a/src/Element/HasPopoverTargetAction.php
+++ b/src/Element/HasPopoverTargetAction.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Element;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\{ElementAttribute, PopoverTargetAction};
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the `popovertargetaction` attribute.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#popovertargetaction
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasPopoverTargetAction
+{
+    /**
+     * Sets the `popovertargetaction` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->popoverTargetAction('toggle');
+     * $element->popoverTargetAction($action);
+     * $element->popoverTargetAction(null);
+     * ```
+     *
+     * @param string|Stringable|UnitEnum|null $value Popover target action, or `null` to remove the attribute.
+     *
+     * @return static New instance with the updated `popovertargetaction` attribute.
+     */
+    public function popoverTargetAction(string|Stringable|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, PopoverTargetAction::cases(), ElementAttribute::POPOVERTARGETACTION);
+
+        return $this->addAttribute(ElementAttribute::POPOVERTARGETACTION, $value);
+    }
+}

--- a/src/Global/HasPopover.php
+++ b/src/Global/HasPopover.php
@@ -31,8 +31,7 @@ trait HasPopover
      * $element->popover(Popover::AUTO);
      * ```
      *
-     * @param string|UnitEnum|null $value Popover state. Use `auto` for auto behavior, `manual` to remove,
-     * `auto`/`manual` or `null` to remove the attribute.
+     * @param string|UnitEnum|null $value Popover state (`auto`, `hint`, `manual`), or `null` to remove the attribute.
      *
      * @throws InvalidArgumentException If the provided value is not valid.
      *

--- a/src/Global/HasPopover.php
+++ b/src/Global/HasPopover.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Global;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\{GlobalAttribute, Popover};
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the `popover` attribute.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasPopover
+{
+    /**
+     * Sets the `popover` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->popover('manual');
+     * $element->popover(Popover::AUTO);
+     * ```
+     *
+     * @param string|UnitEnum|null $value Popover state. Use `auto` for auto behavior, `manual` to remove,
+     * `auto`/`manual` or `null` to remove the attribute.
+     *
+     * @throws InvalidArgumentException If the provided value is not valid.
+     *
+     * @return static New instance with the updated `popover` attribute.
+     *
+     * {@see Popover} for predefined enum values.
+     */
+    public function popover(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, Popover::cases(), GlobalAttribute::POPOVER);
+
+        return $this->addAttribute(GlobalAttribute::POPOVER, $value);
+    }
+}

--- a/src/Values/ElementAttribute.php
+++ b/src/Values/ElementAttribute.php
@@ -53,6 +53,20 @@ enum ElementAttribute: string
     case LOADING = 'loading';
 
     /**
+     * `popovertarget` — Identifies the popover element that is associated with the current element.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#popovertarget
+     */
+    case POPOVERTARGET = 'popovertarget';
+
+    /**
+     * `popovertargetaction` — Defines the action to be performed on the popover element when the current element is activated.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#popovertargetaction
+     */
+    case POPOVERTARGETACTION = 'popovertargetaction';
+
+    /**
      * `referrerpolicy` — Referrer information to send when fetching the resource.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#referrerpolicy

--- a/src/Values/Popover.php
+++ b/src/Values/Popover.php
@@ -30,7 +30,10 @@ enum Popover: string
      * Popover can be "light dismissed" (for example, by clicking outside the popover area), and multiple such popovers
      * can be open at a time.
      *
-     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover#hint
+     * Note: Limited browser support. Currently supported in Chromium-based browsers only (Chrome 133+, Edge 133+,
+     * Opera 118+). Not supported in Firefox or Safari.
+     *
+     * `@link` https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover#hint
      */
     case HINT = 'hint';
 

--- a/src/Values/Popover.php
+++ b/src/Values/Popover.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents values for the HTML `popover` global attribute.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Popover: string
+{
+    /**
+     * `auto` — Element is a popover with "auto" behavior.
+     *
+     * Popover can be "light dismissed" (e.g. by clicking outside the popover area), and only one such popover can be
+     * open at a time.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover#auto
+     */
+    case AUTO = 'auto';
+
+    /**
+     * `hint` — Element is a popover with "hint" behavior.
+     *
+     * Popover can be "light dismissed" (for example, by clicking outside the popover area), and multiple such popovers
+     * can be open at a time.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover#hint
+     */
+    case HINT = 'hint';
+
+    /**
+     * `manual` — Element is a popover with "manual" behavior.
+     *
+     * Popover cannot be "light dismissed", and multiple such popovers can be open at a time.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover#manual
+     */
+    case MANUAL = 'manual';
+}

--- a/src/Values/PopoverTargetAction.php
+++ b/src/Values/PopoverTargetAction.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents the `popovertargetaction` attribute values.
+ *
+ * Usage example:
+ * ```php
+ * $button->popovertargetaction(PopoverTargetAction::TOGGLE);
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#popovertargetaction
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum PopoverTargetAction: string
+{
+    /**
+     * `hide` — Hides the popover.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#hide
+     */
+    case HIDE = 'hide';
+
+    /**
+     * `show` — Shows the popover.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#show
+     */
+    case SHOW = 'show';
+
+    /**
+     * `toggle` — Toggles the visibility of the popover.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#toggle
+     */
+    case TOGGLE = 'toggle';
+}

--- a/tests/Element/HasPopoverTargetActionTest.php
+++ b/tests/Element/HasPopoverTargetActionTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Element;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\Element\HasPopoverTargetAction;
+use UIAwesome\Html\Attribute\Tests\Provider\Element\PopoverTargetActionProvider;
+use UIAwesome\Html\Attribute\Values\{ElementAttribute, PopoverTargetAction};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasPopoverTargetAction} trait managing the `popovertargetaction` HTML attribute.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `popovertargetaction` attribute is not provided.
+ * - Sets the `popovertargetaction` HTML attribute and renders the expected output.
+ * - Verifies invalid `popovertargetaction` values throw an `InvalidArgumentException`.
+ *
+ * {@see PopoverTargetActionProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasPopoverTargetActionTest extends TestCase
+{
+    public function testReturnEmptyWhenPopoverTargetActionAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasPopoverTargetAction;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingPopoverTargetActionAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasPopoverTargetAction;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->popoverTargetAction(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(PopoverTargetActionProvider::class, 'values')]
+    public function testSetPopoverTargetActionAttributeValue(
+        string|Stringable|UnitEnum|null $popoverTargetAction,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasPopoverTargetAction;
+        };
+
+        $instance = $instance->attributes($attributes)->popoverTargetAction($popoverTargetAction);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(ElementAttribute::POPOVERTARGETACTION, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingPopoverTargetActionValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasPopoverTargetAction;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                ElementAttribute::POPOVERTARGETACTION->value,
+                implode('\', \'', Enum::normalizeArray(PopoverTargetAction::cases())),
+            ),
+        );
+
+        $instance->popoverTargetAction('invalid-value');
+    }
+}

--- a/tests/Element/HasPopoverTargetTest.php
+++ b/tests/Element/HasPopoverTargetTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Element;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\Element\HasPopoverTarget;
+use UIAwesome\Html\Attribute\Tests\Provider\Element\PopoverTargetProvider;
+use UIAwesome\Html\Attribute\Values\ElementAttribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasPopoverTarget} trait managing the `popovertarget` HTML attribute.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `popovertarget` attribute is not provided.
+ * - Sets the `popovertarget` HTML attribute and renders the expected output.
+ *
+ * {@see PopoverTargetProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasPopoverTargetTest extends TestCase
+{
+    public function testReturnEmptyWhenPopoverTargetAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasPopoverTarget;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingPopoverTargetAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasPopoverTarget;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->popoverTarget(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(PopoverTargetProvider::class, 'values')]
+    public function testSetPopoverTargetAttributeValue(
+        string|Stringable|UnitEnum|null $popoverTarget,
+        array $attributes,
+        string|Stringable|UnitEnum $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasPopoverTarget;
+        };
+
+        $instance = $instance->attributes($attributes)->popoverTarget($popoverTarget);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(ElementAttribute::POPOVERTARGET, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Form/HasMaxlengthTest.php
+++ b/tests/Form/HasMaxlengthTest.php
@@ -91,7 +91,7 @@ final class HasMaxlengthTest extends TestCase
     }
 
     #[DataProviderExternal(MaxlengthProvider::class, 'invalidValues')]
-    public function testThrowInvalidArgumentExceptionForSettingInvalidMaxlengthAttribute(
+    public function testThrowInvalidArgumentExceptionForSettingMaxlengthAttribute(
         int|string|Stringable|UnitEnum $maxlength,
     ): void {
         $instance = new class {

--- a/tests/Form/HasMinlengthTest.php
+++ b/tests/Form/HasMinlengthTest.php
@@ -91,7 +91,7 @@ final class HasMinlengthTest extends TestCase
     }
 
     #[DataProviderExternal(MinlengthProvider::class, 'invalidValues')]
-    public function testThrowInvalidArgumentExceptionForSettingInvalidMinlengthAttribute(
+    public function testThrowInvalidArgumentExceptionForSettingMinlengthAttribute(
         int|string|Stringable|UnitEnum $minlength,
     ): void {
         $instance = new class {

--- a/tests/Global/HasContentEditableTest.php
+++ b/tests/Global/HasContentEditableTest.php
@@ -89,7 +89,7 @@ final class HasContentEditableTest extends TestCase
         );
     }
 
-    public function testThrowInvalidArgumentExceptionForSettingInvalidContentEditableValue(): void
+    public function testThrowInvalidArgumentExceptionForSettingContentEditableValue(): void
     {
         $instance = new class {
             use HasAttributes;

--- a/tests/Global/HasDirTest.php
+++ b/tests/Global/HasDirTest.php
@@ -89,7 +89,7 @@ final class HasDirTest extends TestCase
         );
     }
 
-    public function testThrowInvalidArgumentExceptionForSettingInvalidDirValue(): void
+    public function testThrowInvalidArgumentExceptionForSettingDirValue(): void
     {
         $instance = new class {
             use HasAttributes;

--- a/tests/Global/HasDraggableTest.php
+++ b/tests/Global/HasDraggableTest.php
@@ -89,7 +89,7 @@ final class HasDraggableTest extends TestCase
         );
     }
 
-    public function testThrowInvalidArgumentExceptionForSettingInvalidDraggableValue(): void
+    public function testThrowInvalidArgumentExceptionForSettingDraggableValue(): void
     {
         $instance = new class {
             use HasAttributes;

--- a/tests/Global/HasPopoverTest.php
+++ b/tests/Global/HasPopoverTest.php
@@ -7,36 +7,36 @@ namespace UIAwesome\Html\Attribute\Tests\Global;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
-use UIAwesome\Html\Attribute\Global\HasTranslate;
-use UIAwesome\Html\Attribute\Tests\Provider\Global\TranslateProvider;
-use UIAwesome\Html\Attribute\Values\{GlobalAttribute, Translate};
+use UIAwesome\Html\Attribute\Global\HasPopover;
+use UIAwesome\Html\Attribute\Tests\Provider\Global\PopoverProvider;
+use UIAwesome\Html\Attribute\Values\{GlobalAttribute, Popover};
 use UIAwesome\Html\Helper\{Attributes, Enum};
 use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Mixin\HasAttributes;
 use UnitEnum;
 
 /**
- * Unit tests for the {@see HasTranslate} trait managing the `translate` global HTML attribute.
+ * Unit tests for the {@see HasPopover} trait managing the `popover` global HTML attribute.
  *
  * Test coverage.
  * - Ensures fluent setters return new instances (immutability).
- * - Ensures no attributes are set when the `translate` attribute is not provided.
- * - Sets the `translate` global HTML attribute and renders the expected output.
- * - Verifies invalid `translate` values throw an `InvalidArgumentException`.
+ * - Ensures no attributes are set when the `popover` attribute is not provided.
+ * - Sets the `popover` global HTML attribute and renders the expected output.
+ * - Verifies invalid `popover` values throw an `InvalidArgumentException`.
  *
- * {@see TranslateProvider} for test case data providers.
+ * {@see PopoverProvider} for test case data providers.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
 #[Group('global')]
-final class HasTranslateTest extends TestCase
+final class HasPopoverTest extends TestCase
 {
-    public function testReturnEmptyWhenTranslateAttributeNotSet(): void
+    public function testReturnEmptyWhenPopoverAttributeNotSet(): void
     {
         $instance = new class {
             use HasAttributes;
-            use HasTranslate;
+            use HasPopover;
         };
 
         self::assertEmpty(
@@ -45,16 +45,16 @@ final class HasTranslateTest extends TestCase
         );
     }
 
-    public function testReturnNewInstanceWhenSettingTranslateAttribute(): void
+    public function testReturnNewInstanceWhenSettingPopoverAttribute(): void
     {
         $instance = new class {
             use HasAttributes;
-            use HasTranslate;
+            use HasPopover;
         };
 
         self::assertNotSame(
             $instance,
-            $instance->translate(''),
+            $instance->popover(null),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
     }
@@ -62,24 +62,24 @@ final class HasTranslateTest extends TestCase
     /**
      * @phpstan-param mixed[] $attributes
      */
-    #[DataProviderExternal(TranslateProvider::class, 'values')]
-    public function testSetTranslateAttributeValue(
-        bool|string|UnitEnum|null $translate,
+    #[DataProviderExternal(PopoverProvider::class, 'values')]
+    public function testSetPopoverAttributeValue(
+        string|UnitEnum|null $popover,
         array $attributes,
-        bool|string|UnitEnum $expectedValue,
+        string|UnitEnum $expectedValue,
         string $expectedRenderAttribute,
         string $message,
     ): void {
         $instance = new class {
             use HasAttributes;
-            use HasTranslate;
+            use HasPopover;
         };
 
-        $instance = $instance->attributes($attributes)->translate($translate);
+        $instance = $instance->attributes($attributes)->popover($popover);
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(GlobalAttribute::TRANSLATE, ''),
+            $instance->getAttribute(GlobalAttribute::POPOVER, ''),
             $message,
         );
         self::assertSame(
@@ -89,22 +89,22 @@ final class HasTranslateTest extends TestCase
         );
     }
 
-    public function testThrowInvalidArgumentExceptionForSettingTranslateValue(): void
+    public function testThrowInvalidArgumentExceptionForSettingPopoverValue(): void
     {
         $instance = new class {
             use HasAttributes;
-            use HasTranslate;
+            use HasPopover;
         };
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             Message::VALUE_NOT_IN_LIST->getMessage(
                 'invalid-value',
-                GlobalAttribute::TRANSLATE->value,
-                implode('\', \'', Enum::normalizeArray(Translate::cases())),
+                GlobalAttribute::POPOVER->value,
+                implode('\', \'', Enum::normalizeArray(Popover::cases())),
             ),
         );
 
-        $instance->translate('invalid-value');
+        $instance->popover('invalid-value');
     }
 }

--- a/tests/Global/HasRoleTest.php
+++ b/tests/Global/HasRoleTest.php
@@ -90,7 +90,7 @@ final class HasRoleTest extends TestCase
         );
     }
 
-    public function testThrowInvalidArgumentExceptionForSettingInvalidRoleValue(): void
+    public function testThrowInvalidArgumentExceptionForSettingRoleValue(): void
     {
         $instance = new class {
             use HasAttributes;

--- a/tests/Global/HasSpellcheckTest.php
+++ b/tests/Global/HasSpellcheckTest.php
@@ -88,7 +88,7 @@ final class HasSpellcheckTest extends TestCase
         );
     }
 
-    public function testThrowInvalidArgumentExceptionForSettingInvalidSpellcheckValue(): void
+    public function testThrowInvalidArgumentExceptionForSettingSpellcheckValue(): void
     {
         $instance = new class {
             use HasAttributes;

--- a/tests/Global/HasTabIndexTest.php
+++ b/tests/Global/HasTabIndexTest.php
@@ -90,7 +90,7 @@ final class HasTabIndexTest extends TestCase
     }
 
     #[DataProviderExternal(TabIndexProvider::class, 'invalidValues')]
-    public function testThrowInvalidArgumentExceptionForSettingInvalidTabIndexAttribute(int|string $tabIndex): void
+    public function testThrowInvalidArgumentExceptionForSettingTabIndexAttribute(int|string $tabIndex): void
     {
         $instance = new class {
             use HasAttributes;

--- a/tests/Provider/Element/PopoverTargetActionProvider.php
+++ b/tests/Provider/Element/PopoverTargetActionProvider.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Provider\Element;
+
+use PHPForge\Support\EnumDataProvider;
+use Stringable;
+use UIAwesome\Html\Attribute\Values\{ElementAttribute, PopoverTargetAction};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Element\HasPopoverTargetActionTest} test cases.
+ *
+ * Provides representative input/output pairs for the `popovertargetaction` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class PopoverTargetActionProvider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{string|Stringable|UnitEnum|null, mixed[], string|Stringable|UnitEnum, string, string},
+     * >
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataProvider::attributeCases(
+            PopoverTargetAction::class,
+            ElementAttribute::POPOVERTARGETACTION,
+        );
+
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'show';
+            }
+        };
+
+        $staticCases = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'show',
+                ['popovertargetaction' => 'hide'],
+                'show',
+                ' popovertargetaction="show"',
+                "Should return new 'popovertargetaction' after replacing the existing 'popovertargetaction' attribute.",
+            ],
+            'string' => [
+                'toggle',
+                [],
+                'toggle',
+                ' popovertargetaction="toggle"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' popovertargetaction="show"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['popovertargetaction' => 'toggle'],
+                '',
+                '',
+                "Should unset the 'popovertargetaction' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$enumCases, ...$staticCases];
+    }
+}

--- a/tests/Provider/Element/PopoverTargetProvider.php
+++ b/tests/Provider/Element/PopoverTargetProvider.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Provider\Element;
+
+use PHPForge\Support\Stub\{BackedString, Unit};
+use Stringable;
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Element\HasPopoverTargetTest} test cases.
+ *
+ * Provides representative input/output pairs for the `popovertarget` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class PopoverTargetProvider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{string|Stringable|UnitEnum|null, mixed[], string|Stringable|UnitEnum, string, string},
+     * >
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'popover-id';
+            }
+        };
+
+        return [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'enum backed string' => [
+                BackedString::VALUE,
+                [],
+                BackedString::VALUE,
+                ' popovertarget="value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'enum unit' => [
+                Unit::value,
+                [],
+                Unit::value,
+                ' popovertarget="value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'popover-id',
+                ['popovertarget' => 'old-popover-id'],
+                'popover-id',
+                ' popovertarget="popover-id"',
+                "Should return new 'popovertarget' after replacing the existing 'popovertarget' attribute.",
+            ],
+            'string' => [
+                'popover-id',
+                [],
+                'popover-id',
+                ' popovertarget="popover-id"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' popovertarget="popover-id"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['popovertarget' => 'popover-id'],
+                '',
+                '',
+                "Should unset the 'popovertarget' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}

--- a/tests/Provider/Global/PopoverProvider.php
+++ b/tests/Provider/Global/PopoverProvider.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Provider\Global;
+
+use PHPForge\Support\EnumDataProvider;
+use UIAwesome\Html\Attribute\Values\{GlobalAttribute, Popover};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Global\HasPopoverTest} test cases.
+ *
+ * Provides representative input/output pairs for the `popover` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class PopoverProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataProvider::attributeCases(Popover::class, GlobalAttribute::POPOVER);
+
+        $staticCase = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                '',
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'manual',
+                ['popover' => 'auto'],
+                'manual',
+                ' popover="manual"',
+                "Should return new 'popover' after replacing the existing 'popover' attribute.",
+            ],
+            'string auto' => [
+                'auto',
+                [],
+                'auto',
+                ' popover="auto"',
+                'Should return the attribute value after setting it.',
+            ],
+            'string manual' => [
+                'manual',
+                [],
+                'manual',
+                ' popover="manual"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['popover' => 'auto'],
+                '',
+                '',
+                "Should unset the 'popover' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$staticCase, ...$enumCases];
+    }
+}

--- a/tests/Provider/Global/PopoverProvider.php
+++ b/tests/Provider/Global/PopoverProvider.php
@@ -25,7 +25,7 @@ final class PopoverProvider
     {
         $enumCases = EnumDataProvider::attributeCases(Popover::class, GlobalAttribute::POPOVER);
 
-        $staticCase = [
+        $staticCases = [
             'empty string' => [
                 '',
                 [],
@@ -70,6 +70,6 @@ final class PopoverProvider
             ],
         ];
 
-        return [...$staticCase, ...$enumCases];
+        return [...$enumCases, ...$staticCases];
     }
 }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
