### PR TITLE
feat(attribute): Add `HasInputmode` trait and `inputmode()` method to manage `inputmode` attribute for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Bug #76: Move `HasDisabled` trait to `UIAwesome\Html\Attribute` namespace and update related imports accordingly (@terabytesoftw)
 - Enh #77: Add `Autocomplete` enum and update `AutocompleteProvider` to add test data (@terabytesoftw)
 - Enh #78: Add `HasPopover`, `HasPopoverTarget`, `HasPopoverTargetAction` traits and `popover()`, `popoverTarget()`, `popoverTargetAction()` methods to manage popover attributes for HTML elements (@terabytesoftw)
+- Enh #79: Add `HasInputmode` trait and `inputmode()` method to manage `inputmode` attribute for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/Global/HasInputMode.php
+++ b/src/Global/HasInputMode.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Global;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\{GlobalAttribute, InputMode};
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the `inputmode` attribute.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasInputMode
+{
+    /**
+     * Sets the `inputmode` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->inputMode(InputMode::NUMERIC);
+     * $element->inputMode('numeric');
+     * ```
+     *
+     * @param string|UnitEnum|null $value Input mode value (`decimal`, `email`, `none`, `numeric`, `search`, `tel`,
+     * `text`, `url`, or `null` to remove the attribute).
+     *
+     * @throws InvalidArgumentException If the provided value is not valid.
+     *
+     * @return static New instance with the updated `inputmode` attribute.
+     */
+    public function inputMode(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, InputMode::cases(), GlobalAttribute::INPUTMODE);
+
+        return $this->addAttribute(GlobalAttribute::INPUTMODE, $value);
+    }
+}

--- a/src/Values/InputMode.php
+++ b/src/Values/InputMode.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+/**
+ * Represents values for the HTML `inputmode` attribute.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum InputMode: string
+{
+    /**
+     * `decimal` - Fractional numeric input keyboard containing the digits and decimal separator.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode#decimal
+     */
+    case DECIMAL = 'decimal';
+
+    /**
+     * `email` - Virtual keyboard optimized for entering email addresses.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode#email
+     */
+    case EMAIL = 'email';
+
+    /**
+     * `none` - No virtual keyboard.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode#none
+     */
+    case NONE = 'none';
+
+    /**
+     * `numeric` - Numeric input keyboard, but only requires the digits 0–9.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode#numeric
+     */
+    case NUMERIC = 'numeric';
+
+    /**
+     * `search` - Virtual keyboard optimized for search input.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode#search
+     */
+    case SEARCH = 'search';
+
+    /**
+     * `tel` - Telephone keypad input, including the digits 0–9, the asterisk (*), and the pound (#) key.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode#tel
+     */
+    case TEL = 'tel';
+
+    /**
+     * `text` - Standard text input keyboard.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode#text
+     */
+    case TEXT = 'text';
+
+    /**
+     * `url` - Virtual keyboard optimized for entering URLs.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode#url
+     */
+    case URL = 'url';
+}

--- a/tests/Global/HasInputModeTest.php
+++ b/tests/Global/HasInputModeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Global;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Global\HasInputMode;
+use UIAwesome\Html\Attribute\Tests\Provider\Global\InputModeProvider;
+use UIAwesome\Html\Attribute\Values\{GlobalAttribute, InputMode};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasInputMode} trait managing the `inputmode` global HTML attribute.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `inputmode` attribute is not provided.
+ * - Sets the `inputmode` global HTML attribute and renders the expected output.
+ * - Verifies invalid `inputmode` values throw an `InvalidArgumentException`.
+ *
+ * {@see InputModeProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('global')]
+final class HasInputModeTest extends TestCase
+{
+    public function testReturnEmptyWhenInputModeAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasInputMode;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingInputModeAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasInputMode;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->inputMode(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(InputModeProvider::class, 'values')]
+    public function testSetInputModeAttributeValue(
+        string|UnitEnum|null $inputMode,
+        array $attributes,
+        string|UnitEnum $expectedValue,
+        string $expectedRenderAttribute,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasInputMode;
+        };
+
+        $instance = $instance->attributes($attributes)->inputMode($inputMode);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(GlobalAttribute::INPUTMODE, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttribute,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingInputModeValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasInputMode;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::INPUTMODE->value,
+                implode('\', \'', Enum::normalizeArray(InputMode::cases())),
+            ),
+        );
+
+        $instance->inputMode('invalid-value');
+    }
+}

--- a/tests/Provider/Global/InputModeProvider.php
+++ b/tests/Provider/Global/InputModeProvider.php
@@ -5,25 +5,25 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Attribute\Tests\Provider\Global;
 
 use PHPForge\Support\EnumDataProvider;
-use UIAwesome\Html\Attribute\Values\{GlobalAttribute, Popover};
+use UIAwesome\Html\Attribute\Values\{GlobalAttribute, InputMode};
 use UnitEnum;
 
 /**
- * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Global\HasPopoverTest} test cases.
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Global\HasInputModeTest} test cases.
  *
- * Provides representative input/output pairs for the `popover` attribute.
+ * Provides representative input/output pairs for the `inputmode` attribute.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-final class PopoverProvider
+final class InputModeProvider
 {
     /**
      * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum, string, string}>
      */
     public static function values(): array
     {
-        $enumCases = EnumDataProvider::attributeCases(Popover::class, GlobalAttribute::POPOVER);
+        $enumCases = EnumDataProvider::attributeCases(InputMode::class, GlobalAttribute::INPUTMODE);
 
         $staticCases = [
             'empty string' => [
@@ -41,25 +41,25 @@ final class PopoverProvider
                 "Should return an empty string when the attribute is set to 'null'.",
             ],
             'replace existing' => [
-                'manual',
-                ['popover' => 'auto'],
-                'manual',
-                ' popover="manual"',
-                "Should return new 'popover' after replacing the existing 'popover' attribute.",
+                'decimal',
+                ['inputmode' => 'numeric'],
+                'decimal',
+                ' inputmode="decimal"',
+                "Should return new 'inputmode' after replacing the existing 'inputmode' attribute.",
             ],
             'string' => [
-                'auto',
+                'text',
                 [],
-                'auto',
-                ' popover="auto"',
+                'text',
+                ' inputmode="text"',
                 'Should return the attribute value after setting it.',
             ],
             'unset with null' => [
                 null,
-                ['popover' => 'auto'],
+                ['inputmode' => 'text'],
                 '',
                 '',
-                "Should unset the 'popover' attribute when 'null' is provided after a value.",
+                "Should unset the 'inputmode' attribute when 'null' is provided after a value.",
             ],
         ];
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
