### PR TITLE
fix(dependencies): Update `ui-awesome/html-helper` requirement to use stable version constraint `^0.7` in `composer.json`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Enh #79: Add `HasInputmode` trait and `inputmode()` method to manage `inputmode` attribute for HTML elements (@terabytesoftw)
 - Bug #80: Update `value()` method in `HasValue` trait to accept boolean values and adjust related tests and data provider (@terabytesoftw)
 - Bug #81: Migrate mixin attribute setters and tests to the simplified API (@terabytesoftw)
+- Bug #82: Update `ui-awesome/html-helper` requirement to use stable version constraint `^0.7` in `composer.json` (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.1",
-        "ui-awesome/html-helper": "dev-main as 0.7.0",
+        "ui-awesome/html-helper": "^0.7",
         "ui-awesome/html-mixin": "^0.4"
     },
     "require-dev": {


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
