### PR TITLE
fix(attribute): Better naming prefix `CanBe` for boolean attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Bug #82: Update `ui-awesome/html-helper` requirement to use stable version constraint `^0.7` in `composer.json` (@terabytesoftw)
 - Enh #83: Enhance `HasAria`, `HasData`, and `HasEvents` traits to support prefix attributes `aria-`, `data-`, and `on` (@terabytesoftw)
 - Bug #84: Refactor attribute documentation in traits (@terabytesoftw)
+- Bug #85: Better naming prefix `CanBe` for boolean attributes (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 - Bug #82: Update `ui-awesome/html-helper` requirement to use stable version constraint `^0.7` in `composer.json` (@terabytesoftw)
 - Enh #83: Enhance `HasAria`, `HasData`, and `HasEvents` traits to support prefix attributes `aria-`, `data-`, and `on` (@terabytesoftw)
 - Bug #84: Refactor attribute documentation in traits (@terabytesoftw)
-- Bug #85: Better naming prefix for boolean attributes (@terabytesoftw)
+- Bug #85: Bug `#85`: Rename boolean attribute traits from `Has*` prefix to improve naming clarity (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 - Bug #82: Update `ui-awesome/html-helper` requirement to use stable version constraint `^0.7` in `composer.json` (@terabytesoftw)
 - Enh #83: Enhance `HasAria`, `HasData`, and `HasEvents` traits to support prefix attributes `aria-`, `data-`, and `on` (@terabytesoftw)
 - Bug #84: Refactor attribute documentation in traits (@terabytesoftw)
-- Bug #85: Better naming prefix `CanBe` for boolean attributes (@terabytesoftw)
+- Bug #85: Better naming prefix for boolean attributes (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/CanBeDisabled.php
+++ b/src/CanBeDisabled.php
@@ -15,7 +15,7 @@ use UIAwesome\Html\Attribute\Values\Attribute;
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-trait HasDisabled
+trait CanBeDisabled
 {
     /**
      * Sets the `disabled` attribute.
@@ -23,7 +23,6 @@ trait HasDisabled
      * Usage example:
      * ```php
      * $element->disabled(true);
-     * $element->disabled(false);
      * $element->disabled(null);
      * ```
      *

--- a/src/Form/CanBeChecked.php
+++ b/src/Form/CanBeChecked.php
@@ -15,7 +15,7 @@ use UIAwesome\Html\Attribute\Values\Attribute;
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-trait HasChecked
+trait CanBeChecked
 {
     /**
      * Sets the `checked` attribute.
@@ -23,7 +23,6 @@ trait HasChecked
      * Usage example:
      * ```php
      * $element->checked(true);
-     * $element->checked(false);
      * $element->checked(null);
      * ```
      *

--- a/src/Form/CanBeMultiple.php
+++ b/src/Form/CanBeMultiple.php
@@ -15,7 +15,7 @@ use UIAwesome\Html\Attribute\Values\Attribute;
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-trait HasMultiple
+trait CanBeMultiple
 {
     /**
      * Sets the `multiple` attribute.
@@ -23,7 +23,6 @@ trait HasMultiple
      * Usage example:
      * ```php
      * $element->multiple(true);
-     * $element->multiple(false);
      * $element->multiple(null);
      * ```
      *

--- a/src/Form/CanBeReadonly.php
+++ b/src/Form/CanBeReadonly.php
@@ -15,7 +15,7 @@ use UIAwesome\Html\Attribute\Values\Attribute;
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-trait HasReadonly
+trait CanBeReadonly
 {
     /**
      * Sets the `readonly` attribute.
@@ -23,7 +23,6 @@ trait HasReadonly
      * Usage example:
      * ```php
      * $element->readonly(true);
-     * $element->readonly(false);
      * $element->readonly(null);
      * ```
      *

--- a/src/Form/CanBeRequired.php
+++ b/src/Form/CanBeRequired.php
@@ -15,7 +15,7 @@ use UIAwesome\Html\Attribute\Values\Attribute;
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-trait HasRequired
+trait CanBeRequired
 {
     /**
      * Sets the `required` attribute.
@@ -23,7 +23,6 @@ trait HasRequired
      * Usage example:
      * ```php
      * $element->required(true);
-     * $element->required(false);
      * $element->required(null);
      * ```
      *

--- a/src/Global/CanBeAutofocus.php
+++ b/src/Global/CanBeAutofocus.php
@@ -25,11 +25,12 @@ trait CanBeAutofocus
      * $element->autofocus(true);
      * ```
      *
-     * @param bool $value Whether to enable autofocus. Use `true` to enable and `false` to disable.
+     * @param bool|null $value Whether to enable autofocus. Use `true` to enable, `false` to disable, or `null` to
+     * remove the attribute.
      *
      * @return static New instance with the updated `autofocus` attribute.
      */
-    public function autofocus(bool $value): static
+    public function autofocus(bool|null $value): static
     {
         return $this->setAttribute(GlobalAttribute::AUTOFOCUS, $value);
     }

--- a/src/Global/CanBeHidden.php
+++ b/src/Global/CanBeHidden.php
@@ -26,11 +26,12 @@ trait CanBeHidden
      * $element->hidden(false);
      * ```
      *
-     * @param bool $value Whether to hide the element. Use `true` to hide and `false` to show.
+     * @param bool|null $value Whether to hide the element. Use `true` to hide, `false` to show, or `null` to remove the
+     * attribute.
      *
      * @return static New instance with the updated `hidden` attribute.
      */
-    public function hidden(bool $value): static
+    public function hidden(bool|null $value): static
     {
         return $this->setAttribute(GlobalAttribute::HIDDEN, $value);
     }

--- a/tests/CanBeDisabledTest.php
+++ b/tests/CanBeDisabledTest.php
@@ -2,37 +2,37 @@
 
 declare(strict_types=1);
 
-namespace UIAwesome\Html\Attribute\Tests\Form;
+namespace UIAwesome\Html\Attribute\Tests;
 
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
-use UIAwesome\Html\Attribute\Form\HasChecked;
-use UIAwesome\Html\Attribute\Tests\Provider\Form\CheckedProvider;
+use UIAwesome\Html\Attribute\CanBeDisabled;
+use UIAwesome\Html\Attribute\Tests\Provider\DisabledProvider;
 use UIAwesome\Html\Attribute\Values\Attribute;
 use UIAwesome\Html\Helper\Attributes;
 use UIAwesome\Html\Mixin\HasAttributes;
 
 /**
- * Unit tests for the {@see HasChecked} trait managing the `checked` HTML attribute.
+ * Unit tests for the {@see CanBeDisabled} trait managing the `disabled` HTML attribute.
  *
  * Test coverage.
  * - Ensures fluent setters return new instances (immutability).
- * - Ensures no attributes are set when the `checked` attribute is not provided.
- * - Sets the `checked` HTML attribute and renders the expected output.
+ * - Ensures no attributes are set when the `disabled` attribute is not provided.
+ * - Sets the `disabled` HTML attribute and renders the expected output.
  *
- * {@see CheckedProvider} for test case data providers.
+ * {@see DisabledProvider} for test case data providers.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
 #[Group('attribute')]
-final class HasCheckedTest extends TestCase
+final class CanBeDisabledTest extends TestCase
 {
-    public function testReturnEmptyWhenCheckedAttributeNotSet(): void
+    public function testReturnEmptyWhenDisabledAttributeNotSet(): void
     {
         $instance = new class {
+            use CanBeDisabled;
             use HasAttributes;
-            use HasChecked;
         };
 
         self::assertEmpty(
@@ -41,16 +41,16 @@ final class HasCheckedTest extends TestCase
         );
     }
 
-    public function testReturnNewInstanceWhenSettingCheckedAttribute(): void
+    public function testReturnNewInstanceWhenSettingDisabledAttribute(): void
     {
         $instance = new class {
+            use CanBeDisabled;
             use HasAttributes;
-            use HasChecked;
         };
 
         self::assertNotSame(
             $instance,
-            $instance->checked(null),
+            $instance->disabled(null),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
     }
@@ -58,24 +58,24 @@ final class HasCheckedTest extends TestCase
     /**
      * @phpstan-param mixed[] $attributes
      */
-    #[DataProviderExternal(CheckedProvider::class, 'values')]
-    public function testSetCheckedAttributeValue(
-        bool|null $checked,
+    #[DataProviderExternal(DisabledProvider::class, 'values')]
+    public function testSetDisabledAttributeValue(
+        bool|null $disabled,
         array $attributes,
-        bool|string|null $expectedValue,
+        bool|null $expectedValue,
         string $expectedRenderAttributes,
         string $message,
     ): void {
         $instance = new class {
+            use CanBeDisabled;
             use HasAttributes;
-            use HasChecked;
         };
 
-        $instance = $instance->attributes($attributes)->checked($checked);
+        $instance = $instance->attributes($attributes)->disabled($disabled);
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(Attribute::CHECKED, ''),
+            $instance->getAttribute(Attribute::DISABLED, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Form/CanBeCheckedTest.php
+++ b/tests/Form/CanBeCheckedTest.php
@@ -2,37 +2,37 @@
 
 declare(strict_types=1);
 
-namespace UIAwesome\Html\Attribute\Tests;
+namespace UIAwesome\Html\Attribute\Tests\Form;
 
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
-use UIAwesome\Html\Attribute\HasDisabled;
-use UIAwesome\Html\Attribute\Tests\Provider\DisabledProvider;
+use UIAwesome\Html\Attribute\Form\CanBeChecked;
+use UIAwesome\Html\Attribute\Tests\Provider\Form\CheckedProvider;
 use UIAwesome\Html\Attribute\Values\Attribute;
 use UIAwesome\Html\Helper\Attributes;
 use UIAwesome\Html\Mixin\HasAttributes;
 
 /**
- * Unit tests for the {@see HasDisabled} trait managing the `disabled` HTML attribute.
+ * Unit tests for the {@see CanBeChecked} trait managing the `checked` HTML attribute.
  *
  * Test coverage.
  * - Ensures fluent setters return new instances (immutability).
- * - Ensures no attributes are set when the `disabled` attribute is not provided.
- * - Sets the `disabled` HTML attribute and renders the expected output.
+ * - Ensures no attributes are set when the `checked` attribute is not provided.
+ * - Sets the `checked` HTML attribute and renders the expected output.
  *
- * {@see DisabledProvider} for test case data providers.
+ * {@see CheckedProvider} for test case data providers.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
 #[Group('attribute')]
-final class HasDisabledTest extends TestCase
+final class CanBeCheckedTest extends TestCase
 {
-    public function testReturnEmptyWhenDisabledAttributeNotSet(): void
+    public function testReturnEmptyWhenCheckedAttributeNotSet(): void
     {
         $instance = new class {
+            use CanBeChecked;
             use HasAttributes;
-            use HasDisabled;
         };
 
         self::assertEmpty(
@@ -41,16 +41,16 @@ final class HasDisabledTest extends TestCase
         );
     }
 
-    public function testReturnNewInstanceWhenSettingDisabledAttribute(): void
+    public function testReturnNewInstanceWhenSettingCheckedAttribute(): void
     {
         $instance = new class {
+            use CanBeChecked;
             use HasAttributes;
-            use HasDisabled;
         };
 
         self::assertNotSame(
             $instance,
-            $instance->disabled(null),
+            $instance->checked(null),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
     }
@@ -58,24 +58,24 @@ final class HasDisabledTest extends TestCase
     /**
      * @phpstan-param mixed[] $attributes
      */
-    #[DataProviderExternal(DisabledProvider::class, 'values')]
-    public function testSetDisabledAttributeValue(
-        bool|null $disabled,
+    #[DataProviderExternal(CheckedProvider::class, 'values')]
+    public function testSetCheckedAttributeValue(
+        bool|null $checked,
         array $attributes,
-        bool|string|null $expectedValue,
+        bool|null $expectedValue,
         string $expectedRenderAttributes,
         string $message,
     ): void {
         $instance = new class {
+            use CanBeChecked;
             use HasAttributes;
-            use HasDisabled;
         };
 
-        $instance = $instance->attributes($attributes)->disabled($disabled);
+        $instance = $instance->attributes($attributes)->checked($checked);
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(Attribute::DISABLED, ''),
+            $instance->getAttribute(Attribute::CHECKED, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Form/CanBeMultipleTest.php
+++ b/tests/Form/CanBeMultipleTest.php
@@ -6,33 +6,33 @@ namespace UIAwesome\Html\Attribute\Tests\Form;
 
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
-use UIAwesome\Html\Attribute\Form\HasRequired;
-use UIAwesome\Html\Attribute\Tests\Provider\Form\RequiredProvider;
+use UIAwesome\Html\Attribute\Form\CanBeMultiple;
+use UIAwesome\Html\Attribute\Tests\Provider\Form\MultipleProvider;
 use UIAwesome\Html\Attribute\Values\Attribute;
 use UIAwesome\Html\Helper\Attributes;
 use UIAwesome\Html\Mixin\HasAttributes;
 
 /**
- * Unit tests for the {@see HasRequired} trait managing the `required` HTML attribute.
+ * Unit tests for the {@see CanBeMultiple} trait managing the `multiple` HTML attribute.
  *
  * Test coverage.
  * - Ensures fluent setters return new instances (immutability).
- * - Ensures no attributes are set when the `required` attribute is not provided.
- * - Sets the `required` HTML attribute and renders the expected output.
+ * - Ensures no attributes are set when the `multiple` attribute is not provided.
+ * - Sets the `multiple` HTML attribute and renders the expected output.
  *
- * {@see RequiredProvider} for test case data providers.
+ * {@see MultipleProvider} for test case data providers.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
 #[Group('attribute')]
-final class HasRequiredTest extends TestCase
+final class CanBeMultipleTest extends TestCase
 {
-    public function testReturnEmptyWhenRequiredAttributeNotSet(): void
+    public function testReturnEmptyWhenMultipleAttributeNotSet(): void
     {
         $instance = new class {
+            use CanBeMultiple;
             use HasAttributes;
-            use HasRequired;
         };
 
         self::assertEmpty(
@@ -41,16 +41,16 @@ final class HasRequiredTest extends TestCase
         );
     }
 
-    public function testReturnNewInstanceWhenSettingRequiredAttribute(): void
+    public function testReturnNewInstanceWhenSettingMultipleAttribute(): void
     {
         $instance = new class {
+            use CanBeMultiple;
             use HasAttributes;
-            use HasRequired;
         };
 
         self::assertNotSame(
             $instance,
-            $instance->required(null),
+            $instance->multiple(null),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
     }
@@ -58,24 +58,24 @@ final class HasRequiredTest extends TestCase
     /**
      * @phpstan-param mixed[] $attributes
      */
-    #[DataProviderExternal(RequiredProvider::class, 'values')]
-    public function testSetRequiredAttributeValue(
-        bool|null $required,
+    #[DataProviderExternal(MultipleProvider::class, 'values')]
+    public function testSetMultipleAttributeValue(
+        bool|null $multiple,
         array $attributes,
         bool|null $expectedValue,
         string $expectedRenderAttributes,
         string $message,
     ): void {
         $instance = new class {
+            use CanBeMultiple;
             use HasAttributes;
-            use HasRequired;
         };
 
-        $instance = $instance->attributes($attributes)->required($required);
+        $instance = $instance->attributes($attributes)->multiple($multiple);
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(Attribute::REQUIRED, null),
+            $instance->getAttribute(Attribute::MULTIPLE, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Form/CanBeReadonlyTest.php
+++ b/tests/Form/CanBeReadonlyTest.php
@@ -6,33 +6,33 @@ namespace UIAwesome\Html\Attribute\Tests\Form;
 
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
-use UIAwesome\Html\Attribute\Form\HasMultiple;
-use UIAwesome\Html\Attribute\Tests\Provider\Form\MultipleProvider;
+use UIAwesome\Html\Attribute\Form\CanBeReadonly;
+use UIAwesome\Html\Attribute\Tests\Provider\Form\ReadonlyProvider;
 use UIAwesome\Html\Attribute\Values\Attribute;
 use UIAwesome\Html\Helper\Attributes;
 use UIAwesome\Html\Mixin\HasAttributes;
 
 /**
- * Unit tests for the {@see HasMultiple} trait managing the `multiple` HTML attribute.
+ * Unit tests for the {@see CanBeReadonly} trait managing the `readonly` HTML attribute.
  *
  * Test coverage.
  * - Ensures fluent setters return new instances (immutability).
- * - Ensures no attributes are set when the `multiple` attribute is not provided.
- * - Sets the `multiple` HTML attribute and renders the expected output.
+ * - Ensures no attributes are set when the `readonly` attribute is not provided.
+ * - Sets the `readonly` HTML attribute and renders the expected output.
  *
- * {@see MultipleProvider} for test case data providers.
+ * {@see ReadonlyProvider} for test case data providers.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
 #[Group('attribute')]
-final class HasMultipleTest extends TestCase
+final class CanBeReadonlyTest extends TestCase
 {
-    public function testReturnEmptyWhenMultipleAttributeNotSet(): void
+    public function testReturnEmptyWhenReadonlyAttributeNotSet(): void
     {
         $instance = new class {
+            use CanBeReadonly;
             use HasAttributes;
-            use HasMultiple;
         };
 
         self::assertEmpty(
@@ -41,16 +41,16 @@ final class HasMultipleTest extends TestCase
         );
     }
 
-    public function testReturnNewInstanceWhenSettingMultipleAttribute(): void
+    public function testReturnNewInstanceWhenSettingReadonlyAttribute(): void
     {
         $instance = new class {
+            use CanBeReadonly;
             use HasAttributes;
-            use HasMultiple;
         };
 
         self::assertNotSame(
             $instance,
-            $instance->multiple(null),
+            $instance->readonly(null),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
     }
@@ -58,24 +58,24 @@ final class HasMultipleTest extends TestCase
     /**
      * @phpstan-param mixed[] $attributes
      */
-    #[DataProviderExternal(MultipleProvider::class, 'values')]
-    public function testSetMultipleAttributeValue(
-        bool|null $multiple,
+    #[DataProviderExternal(ReadonlyProvider::class, 'values')]
+    public function testSetReadonlyAttributeValue(
+        bool|null $readonly,
         array $attributes,
-        bool|string|null $expectedValue,
+        bool|null $expectedValue,
         string $expectedRenderAttributes,
         string $message,
     ): void {
         $instance = new class {
+            use CanBeReadonly;
             use HasAttributes;
-            use HasMultiple;
         };
 
-        $instance = $instance->attributes($attributes)->multiple($multiple);
+        $instance = $instance->attributes($attributes)->readonly($readonly);
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(Attribute::MULTIPLE, ''),
+            $instance->getAttribute(Attribute::READONLY, ''),
             $message,
         );
         self::assertSame(

--- a/tests/Form/CanBeRequiredTest.php
+++ b/tests/Form/CanBeRequiredTest.php
@@ -6,33 +6,33 @@ namespace UIAwesome\Html\Attribute\Tests\Form;
 
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
-use UIAwesome\Html\Attribute\Form\HasReadonly;
-use UIAwesome\Html\Attribute\Tests\Provider\Form\ReadonlyProvider;
+use UIAwesome\Html\Attribute\Form\CanBeRequired;
+use UIAwesome\Html\Attribute\Tests\Provider\Form\RequiredProvider;
 use UIAwesome\Html\Attribute\Values\Attribute;
 use UIAwesome\Html\Helper\Attributes;
 use UIAwesome\Html\Mixin\HasAttributes;
 
 /**
- * Unit tests for the {@see HasReadonly} trait managing the `readonly` HTML attribute.
+ * Unit tests for the {@see CanBeRequired} trait managing the `required` HTML attribute.
  *
  * Test coverage.
  * - Ensures fluent setters return new instances (immutability).
- * - Ensures no attributes are set when the `readonly` attribute is not provided.
- * - Sets the `readonly` HTML attribute and renders the expected output.
+ * - Ensures no attributes are set when the `required` attribute is not provided.
+ * - Sets the `required` HTML attribute and renders the expected output.
  *
- * {@see ReadonlyProvider} for test case data providers.
+ * {@see RequiredProvider} for test case data providers.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
 #[Group('attribute')]
-final class HasReadonlyTest extends TestCase
+final class CanBeRequiredTest extends TestCase
 {
-    public function testReturnEmptyWhenReadonlyAttributeNotSet(): void
+    public function testReturnEmptyWhenRequiredAttributeNotSet(): void
     {
         $instance = new class {
+            use CanBeRequired;
             use HasAttributes;
-            use HasReadonly;
         };
 
         self::assertEmpty(
@@ -41,16 +41,16 @@ final class HasReadonlyTest extends TestCase
         );
     }
 
-    public function testReturnNewInstanceWhenSettingReadonlyAttribute(): void
+    public function testReturnNewInstanceWhenSettingRequiredAttribute(): void
     {
         $instance = new class {
+            use CanBeRequired;
             use HasAttributes;
-            use HasReadonly;
         };
 
         self::assertNotSame(
             $instance,
-            $instance->readonly(null),
+            $instance->required(null),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
     }
@@ -58,24 +58,24 @@ final class HasReadonlyTest extends TestCase
     /**
      * @phpstan-param mixed[] $attributes
      */
-    #[DataProviderExternal(ReadonlyProvider::class, 'values')]
-    public function testSetReadonlyAttributeValue(
-        bool|null $readonly,
+    #[DataProviderExternal(RequiredProvider::class, 'values')]
+    public function testSetRequiredAttributeValue(
+        bool|null $required,
         array $attributes,
-        bool|string|null $expectedValue,
+        bool|null $expectedValue,
         string $expectedRenderAttributes,
         string $message,
     ): void {
         $instance = new class {
+            use CanBeRequired;
             use HasAttributes;
-            use HasReadonly;
         };
 
-        $instance = $instance->attributes($attributes)->readonly($readonly);
+        $instance = $instance->attributes($attributes)->required($required);
 
         self::assertSame(
             $expectedValue,
-            $instance->getAttribute(Attribute::READONLY, ''),
+            $instance->getAttribute(Attribute::REQUIRED, null),
             $message,
         );
         self::assertSame(

--- a/tests/Global/CanBeAutofocusTest.php
+++ b/tests/Global/CanBeAutofocusTest.php
@@ -60,9 +60,9 @@ final class CanBeAutofocusTest extends TestCase
      */
     #[DataProviderExternal(AutofocusProvider::class, 'values')]
     public function testSetAutofocusAttributeValue(
-        bool $value,
+        bool|null $value,
         array $attributes,
-        bool|string|null $expectedValue,
+        bool|null $expectedValue,
         string $expectedRenderAttribute,
         string $message,
     ): void {

--- a/tests/Global/CanBeHiddenTest.php
+++ b/tests/Global/CanBeHiddenTest.php
@@ -60,9 +60,9 @@ final class CanBeHiddenTest extends TestCase
      */
     #[DataProviderExternal(HiddenProvider::class, 'values')]
     public function testSetHiddenAttributeValue(
-        bool $value,
+        bool|null $value,
         array $attributes,
-        bool|string|null $expectedValue,
+        bool|null $expectedValue,
         string $expectedRenderAttribute,
         string $message,
     ): void {

--- a/tests/Provider/DisabledProvider.php
+++ b/tests/Provider/DisabledProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Attribute\Tests\Provider;
 
 /**
- * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasDisabledTest} test cases.
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\CanBeDisabledTest} test cases.
  *
  * Provides representative input/output pairs for the `disabled` attribute.
  *
@@ -15,7 +15,7 @@ namespace UIAwesome\Html\Attribute\Tests\Provider;
 final class DisabledProvider
 {
     /**
-     * @phpstan-return array<string, array{bool|null, mixed[], bool|string|null, string, string}>
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|null, string, string}>
      */
     public static function values(): array
     {

--- a/tests/Provider/Form/CheckedProvider.php
+++ b/tests/Provider/Form/CheckedProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Attribute\Tests\Provider\Form;
 
 /**
- * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Form\HasCheckedTest} test cases.
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Form\CanBeCheckedTest} test cases.
  *
  * Provides representative input/output pairs for the `checked` attribute.
  *
@@ -15,7 +15,7 @@ namespace UIAwesome\Html\Attribute\Tests\Provider\Form;
 final class CheckedProvider
 {
     /**
-     * @phpstan-return array<string, array{bool|null, mixed[], bool|string|null, string, string}>
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|null, string, string}>
      */
     public static function values(): array
     {

--- a/tests/Provider/Form/MultipleProvider.php
+++ b/tests/Provider/Form/MultipleProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Attribute\Tests\Provider\Form;
 
 /**
- * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Form\HasMultipleTest} test cases.
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Form\CanBeMultipleTest} test cases.
  *
  * Provides representative input/output pairs for the `multiple` attribute.
  *
@@ -15,7 +15,7 @@ namespace UIAwesome\Html\Attribute\Tests\Provider\Form;
 final class MultipleProvider
 {
     /**
-     * @phpstan-return array<string, array{bool|null, mixed[], bool|string|null, string, string}>
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|null, string, string}>
      */
     public static function values(): array
     {

--- a/tests/Provider/Form/ReadonlyProvider.php
+++ b/tests/Provider/Form/ReadonlyProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Attribute\Tests\Provider\Form;
 
 /**
- * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Form\HasReadonlyTest} test cases.
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Form\CanBeReadonlyTest} test cases.
  *
  * Provides representative input/output pairs for the `readonly` attribute.
  *
@@ -15,7 +15,7 @@ namespace UIAwesome\Html\Attribute\Tests\Provider\Form;
 final class ReadonlyProvider
 {
     /**
-     * @phpstan-return array<string, array{bool|null, mixed[], bool|string|null, string, string}>
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|null, string, string}>
      */
     public static function values(): array
     {

--- a/tests/Provider/Form/RequiredProvider.php
+++ b/tests/Provider/Form/RequiredProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Attribute\Tests\Provider\Form;
 
 /**
- * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Form\HasRequiredTest} test cases.
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Form\CanBeRequiredTest} test cases.
  *
  * Provides representative input/output pairs for the `required` attribute.
  *

--- a/tests/Provider/Global/AutofocusProvider.php
+++ b/tests/Provider/Global/AutofocusProvider.php
@@ -15,7 +15,7 @@ namespace UIAwesome\Html\Attribute\Tests\Provider\Global;
 final class AutofocusProvider
 {
     /**
-     * @phpstan-return array<string, array{bool, mixed[], bool|string, string, string}>
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|null, string, string}>
      */
     public static function values(): array
     {
@@ -34,6 +34,13 @@ final class AutofocusProvider
                 ' autofocus',
                 'Should return the attribute value after setting it.',
             ],
+            'null' => [
+                null,
+                [],
+                null,
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
             'replace existing false' => [
                 false,
                 ['autofocus' => true],
@@ -47,6 +54,13 @@ final class AutofocusProvider
                 true,
                 ' autofocus',
                 "Should return 'true' when replacing existing 'autofocus' attribute with 'true'.",
+            ],
+            'unset with null' => [
+                null,
+                ['autofocus' => true],
+                null,
+                '',
+                "Should unset the 'autofocus' attribute when 'null' is provided after a value.",
             ],
         ];
     }

--- a/tests/Provider/Global/HiddenProvider.php
+++ b/tests/Provider/Global/HiddenProvider.php
@@ -15,7 +15,7 @@ namespace UIAwesome\Html\Attribute\Tests\Provider\Global;
 final class HiddenProvider
 {
     /**
-     * @phpstan-return array<string, array{bool, mixed[], bool|string, string, string}>
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|null, string, string}>
      */
     public static function values(): array
     {
@@ -34,6 +34,13 @@ final class HiddenProvider
                 ' hidden',
                 'Should return the attribute value after setting it.',
             ],
+            'null' => [
+                null,
+                [],
+                null,
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
             'replace existing false' => [
                 false,
                 ['hidden' => true],
@@ -47,6 +54,13 @@ final class HiddenProvider
                 true,
                 ' hidden',
                 "Should return 'true' when replacing existing 'hidden' attribute with 'true'.",
+            ],
+            'unset with null' => [
+                null,
+                ['hidden' => true],
+                null,
+                '',
+                "Should unset the 'hidden' attribute when 'null' is provided after a value.",
             ],
         ];
     }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ✔️                                                              |
