### PR TITLE
feat(attribute): Add `HasAutocapitalize` and `HasAutocorrect` traits and `autocapitalize()`, `autocorrect()` methods to manage `autocapitalize` and `autocorrect` attributes for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Enh #83: Enhance `HasAria`, `HasData`, and `HasEvents` traits to support prefix attributes `aria-`, `data-`, and `on` (@terabytesoftw)
 - Bug #84: Refactor attribute documentation in traits (@terabytesoftw)
 - Bug #85: Bug `#85`: Rename boolean attribute traits from `Has*` prefix to improve naming clarity (@terabytesoftw)
+- Enh #86: Add `HasAutocapitalize` and `HasAutocorrect` traits and `autocapitalize()`, `autocorrect()` methods to manage `autocapitalize` and `autocorrect` attributes for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/Global/HasAutocapitalize.php
+++ b/src/Global/HasAutocapitalize.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Global;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\Autocapitalize;
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the HTML `autocapitalize` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/autocapitalize
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasAutocapitalize
+{
+    /**
+     * Sets the `autocapitalize` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->autocapitalize('sentences')->render();
+     * $element->autocapitalize(\UIAwesome\Html\Attribute\Values\Autocapitalize::SENTENCES)->render();
+     * ```
+     *
+     * @param string|UnitEnum|null $value Capitalization behavior (`none`, `off`, `sentences`, `on`, `words`,
+     * `characters`), or `null` to remove the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `autocapitalize` attribute.
+     *
+     * {@see Autocapitalize} for predefined enum values.
+     */
+    public function autocapitalize(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, Autocapitalize::cases(), 'autocapitalize');
+
+        return $this->setAttribute('autocapitalize', $value);
+    }
+}

--- a/src/Global/HasAutocorrect.php
+++ b/src/Global/HasAutocorrect.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Global;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Values\Autocorrect;
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the HTML `autocorrect` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/autocorrect
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasAutocorrect
+{
+    /**
+     * Sets the `autocorrect` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->autocorrect('on')->render();
+     * $element->autocorrect(\UIAwesome\Html\Attribute\Values\Autocorrect::ON)->render();
+     * ```
+     *
+     * @param string|UnitEnum|null $value Autocorrect behavior (`on` or `off`), or `null` to remove the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `autocorrect` attribute.
+     *
+     * {@see Autocorrect} for predefined enum values.
+     */
+    public function autocorrect(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, Autocorrect::cases(), 'autocorrect');
+
+        return $this->setAttribute('autocorrect', $value);
+    }
+}

--- a/src/Values/Autocapitalize.php
+++ b/src/Values/Autocapitalize.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+
+/**
+ * Represents values for the HTML `autocapitalize` global attribute.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/autocapitalize
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Autocapitalize: string
+{
+    /**
+     * Represents the `characters` token. Automatically capitalizes every character.
+     */
+    case CHARACTERS = 'characters';
+
+    /**
+     * Represents the `none` token. Does not automatically capitalize any text.
+     */
+    case NONE = 'none';
+
+    /**
+     * Represents the `off` token. Alias for `none`.
+     */
+    case OFF = 'off';
+
+    /**
+     * Represents the `on` token. Alias for `sentences`.
+     */
+    case ON = 'on';
+
+    /**
+     * Represents the `sentences` token. Automatically capitalizes the first character of each sentence.
+     */
+    case SENTENCES = 'sentences';
+
+    /**
+     * Represents the `words` token. Automatically capitalizes the first character of each word.
+     */
+    case WORDS = 'words';
+}

--- a/src/Values/Autocapitalize.php
+++ b/src/Values/Autocapitalize.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Attribute\Values;
 
-
 /**
  * Represents values for the HTML `autocapitalize` global attribute.
  *

--- a/src/Values/Autocorrect.php
+++ b/src/Values/Autocorrect.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Values;
+
+
+/**
+ * Represents values for the HTML `autocorrect` global attribute.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/autocorrect
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Autocorrect: string
+{
+    /**
+     * Represents the `off` token. Disables automatic correction of editable text.
+     */
+    case OFF = 'off';
+
+    /**
+     * Represents the `on` token. Enables automatic correction of spelling and punctuation errors.
+     */
+    case ON = 'on';
+}

--- a/src/Values/Autocorrect.php
+++ b/src/Values/Autocorrect.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Attribute\Values;
 
-
 /**
  * Represents values for the HTML `autocorrect` global attribute.
  *

--- a/tests/Global/HasAutocapitalizeTest.php
+++ b/tests/Global/HasAutocapitalizeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Global;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Global\HasAutocapitalize;
+use UIAwesome\Html\Attribute\Tests\Provider\Global\AutocapitalizeProvider;
+use UIAwesome\Html\Attribute\Values\{Autocapitalize, GlobalAttribute};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasAutocapitalize} trait managing the `autocapitalize` global HTML attribute.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `autocapitalize` attribute is not provided.
+ * - Sets the `autocapitalize` global HTML attribute and renders the expected output.
+ * - Verifies invalid `autocapitalize` values throw an `InvalidArgumentException`.
+ *
+ * {@see AutocapitalizeProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('global')]
+final class HasAutocapitalizeTest extends TestCase
+{
+    public function testReturnEmptyWhenAutocapitalizeAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasAutocapitalize;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingAutocapitalizeAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasAutocapitalize;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->autocapitalize(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(AutocapitalizeProvider::class, 'values')]
+    public function testSetAutocapitalizeAttributeValue(
+        string|UnitEnum|null $autocapitalize,
+        array $attributes,
+        string|UnitEnum|null $expectedValue,
+        string $expectedRenderAttribute,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasAutocapitalize;
+        };
+
+        $instance = $instance->attributes($attributes)->autocapitalize($autocapitalize);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(GlobalAttribute::AUTOCAPITALIZE, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttribute,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingAutocapitalizeValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasAutocapitalize;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::AUTOCAPITALIZE->value,
+                implode("', '", Enum::normalizeArray(Autocapitalize::cases())),
+            ),
+        );
+
+        $instance->autocapitalize('invalid-value');
+    }
+}

--- a/tests/Global/HasAutocorrectTest.php
+++ b/tests/Global/HasAutocorrectTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Global;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Global\HasAutocorrect;
+use UIAwesome\Html\Attribute\Tests\Provider\Global\AutocorrectProvider;
+use UIAwesome\Html\Attribute\Values\{Autocorrect, GlobalAttribute};
+use UIAwesome\Html\Helper\{Attributes, Enum};
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasAutocorrect} trait managing the `autocorrect` global HTML attribute.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `autocorrect` attribute is not provided.
+ * - Sets the `autocorrect` global HTML attribute and renders the expected output.
+ * - Verifies invalid `autocorrect` values throw an `InvalidArgumentException`.
+ *
+ * {@see AutocorrectProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('global')]
+final class HasAutocorrectTest extends TestCase
+{
+    public function testReturnEmptyWhenAutocorrectAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasAutocorrect;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingAutocorrectAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasAutocorrect;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->autocorrect(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(AutocorrectProvider::class, 'values')]
+    public function testSetAutocorrectAttributeValue(
+        string|UnitEnum|null $autocorrect,
+        array $attributes,
+        string|UnitEnum|null $expectedValue,
+        string $expectedRenderAttribute,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasAutocorrect;
+        };
+
+        $instance = $instance->attributes($attributes)->autocorrect($autocorrect);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(GlobalAttribute::AUTOCORRECT, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttribute,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingAutocorrectValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasAutocorrect;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::AUTOCORRECT->value,
+                implode("', '", Enum::normalizeArray(Autocorrect::cases())),
+            ),
+        );
+
+        $instance->autocorrect('invalid-value');
+    }
+}

--- a/tests/Provider/Global/AutocapitalizeProvider.php
+++ b/tests/Provider/Global/AutocapitalizeProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Provider\Global;
+
+use PHPForge\Support\EnumDataProvider;
+use UIAwesome\Html\Attribute\Values\{Autocapitalize, GlobalAttribute};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Global\HasAutocapitalizeTest} test cases.
+ *
+ * Provides representative input/output pairs for the `autocapitalize` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class AutocapitalizeProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum|null, string, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataProvider::attributeCases(Autocapitalize::class, GlobalAttribute::AUTOCAPITALIZE);
+
+        $staticCases = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                null,
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'words',
+                ['autocapitalize' => 'sentences'],
+                'words',
+                ' autocapitalize="words"',
+                "Should return new 'autocapitalize' after replacing the existing 'autocapitalize' attribute.",
+            ],
+            'string' => [
+                'sentences',
+                [],
+                'sentences',
+                ' autocapitalize="sentences"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['autocapitalize' => 'sentences'],
+                null,
+                '',
+                "Should unset the 'autocapitalize' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$enumCases, ...$staticCases];
+    }
+}

--- a/tests/Provider/Global/AutocorrectProvider.php
+++ b/tests/Provider/Global/AutocorrectProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Provider\Global;
+
+use PHPForge\Support\EnumDataProvider;
+use UIAwesome\Html\Attribute\Values\{Autocorrect, GlobalAttribute};
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\Global\HasAutocorrectTest} test cases.
+ *
+ * Provides representative input/output pairs for the `autocorrect` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class AutocorrectProvider
+{
+    /**
+     * @phpstan-return array<string, array{string|UnitEnum|null, mixed[], string|UnitEnum|null, string, string}>
+     */
+    public static function values(): array
+    {
+        $enumCases = EnumDataProvider::attributeCases(Autocorrect::class, GlobalAttribute::AUTOCORRECT);
+
+        $staticCases = [
+            'empty string' => [
+                '',
+                [],
+                '',
+                '',
+                'Should return an empty string when setting an empty string.',
+            ],
+            'null' => [
+                null,
+                [],
+                null,
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'on',
+                ['autocorrect' => 'off'],
+                'on',
+                ' autocorrect="on"',
+                "Should return new 'autocorrect' after replacing the existing 'autocorrect' attribute.",
+            ],
+            'string' => [
+                'on',
+                [],
+                'on',
+                ' autocorrect="on"',
+                'Should return the attribute value after setting it.',
+            ],
+            'unset with null' => [
+                null,
+                ['autocorrect' => 'on'],
+                null,
+                '',
+                "Should unset the 'autocorrect' attribute when 'null' is provided after a value.",
+            ],
+        ];
+
+        return [...$enumCases, ...$staticCases];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
