### PR TITLE
feat(attribute): Add `CanBeSelected`, `HasLabel` traits and `selected()`, `label()` methods to manage `selected` and `label` attributes for HTML elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Bug #85: Bug `#85`: Rename boolean attribute traits from `Has*` prefix to improve naming clarity (@terabytesoftw)
 - Enh #86: Add `HasAutocapitalize` and `HasAutocorrect` traits and `autocapitalize()`, `autocorrect()` methods to manage `autocapitalize` and `autocorrect` attributes for HTML elements (@terabytesoftw)
 - Bug #87: Update test method names for clarity by removing redundant `Value` suffix (@terabytesoftw)
+- Enh #88: Add `CanBeSelected`, `HasLabel` traits and `selected()`, `label()` methods to manage `selected` and `label` attributes for HTML elements (@terabytesoftw)
 
 ## 0.5.2 January 29, 2026
 

--- a/src/CanBeSelected.php
+++ b/src/CanBeSelected.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use UIAwesome\Html\Attribute\Values\Attribute;
+
+/**
+ * Provides an immutable API for the `selected` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/option#selected
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait CanBeSelected
+{
+    /**
+     * Sets the `selected` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->selected(true);
+     * $element->selected(null);
+     * ```
+     *
+     * @param bool|null $value Selected state. Use `true` to mark selected, `false` to unselect, or `null` to remove
+     * the attribute.
+     *
+     * @return static New instance with the updated `selected` attribute.
+     */
+    public function selected(bool|null $value): static
+    {
+        return $this->setAttribute(Attribute::SELECTED, $value);
+    }
+}

--- a/src/HasLabel.php
+++ b/src/HasLabel.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the `label` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/option#label
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasLabel
+{
+    /**
+     * Sets the `label` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $element->label('Group label');
+     * $element->label(null);
+     * ```
+     *
+     * @param string|Stringable|UnitEnum|null $value Label text, or `null` to remove the attribute.
+     *
+     * @return static New instance with the updated `label` attribute.
+     */
+    public function label(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->setAttribute(Attribute::LABEL, $value);
+    }
+}

--- a/src/Values/Attribute.php
+++ b/src/Values/Attribute.php
@@ -163,6 +163,13 @@ enum Attribute: string
     case INTEGRITY = 'integrity';
 
     /**
+     * `label` — Text used as a label for an option or option group.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/option#label
+     */
+    case LABEL = 'label';
+
+    /**
      * `list` — Identifies a `<datalist>` element that provides predefined options to suggest to the user.
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#list
@@ -266,6 +273,13 @@ enum Attribute: string
      * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/required
      */
     case REQUIRED = 'required';
+
+    /**
+     * `selected` — Indicates whether an option is initially selected.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/option#selected
+     */
+    case SELECTED = 'selected';
 
     /**
      * `size` — Defines the width of the element (in pixels).

--- a/tests/CanBeSelectedTest.php
+++ b/tests/CanBeSelectedTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\CanBeSelected;
+use UIAwesome\Html\Attribute\Tests\Provider\SelectedProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+
+/**
+ * Unit tests for the {@see CanBeSelected} trait managing the `selected` HTML attribute.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `selected` attribute is not provided.
+ * - Sets the `selected` HTML attribute and renders the expected output.
+ *
+ * {@see SelectedProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class CanBeSelectedTest extends TestCase
+{
+    public function testReturnEmptyWhenSelectedAttributeNotSet(): void
+    {
+        $instance = new class {
+            use CanBeSelected;
+            use HasAttributes;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingSelectedAttribute(): void
+    {
+        $instance = new class {
+            use CanBeSelected;
+            use HasAttributes;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->selected(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(SelectedProvider::class, 'values')]
+    public function testSetSelectedAttributeValue(
+        bool|null $selected,
+        array $attributes,
+        bool|null $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use CanBeSelected;
+            use HasAttributes;
+        };
+
+        $instance = $instance->attributes($attributes)->selected($selected);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::SELECTED, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/HasLabelTest.php
+++ b/tests/HasLabelTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests;
+
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use UIAwesome\Html\Attribute\HasLabel;
+use UIAwesome\Html\Attribute\Tests\Provider\LabelProvider;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Helper\Attributes;
+use UIAwesome\Html\Mixin\HasAttributes;
+use UnitEnum;
+
+/**
+ * Unit tests for the {@see HasLabel} trait managing the `label` HTML attribute.
+ *
+ * Test coverage.
+ * - Ensures fluent setters return new instances (immutability).
+ * - Ensures no attributes are set when the `label` attribute is not provided.
+ * - Sets the `label` HTML attribute and renders the expected output.
+ *
+ * {@see LabelProvider} for test case data providers.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('attribute')]
+final class HasLabelTest extends TestCase
+{
+    public function testReturnEmptyWhenLabelAttributeNotSet(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasLabel;
+        };
+
+        self::assertEmpty(
+            $instance->getAttributes(),
+            'Should have no attributes set when no attribute is provided.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingLabelAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+            use HasLabel;
+        };
+
+        self::assertNotSame(
+            $instance,
+            $instance->label('Group label'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    /**
+     * @phpstan-param mixed[] $attributes
+     */
+    #[DataProviderExternal(LabelProvider::class, 'values')]
+    public function testSetLabelAttributeValue(
+        string|Stringable|UnitEnum|null $label,
+        array $attributes,
+        string|Stringable|UnitEnum|null $expectedValue,
+        string $expectedRenderAttributes,
+        string $message,
+    ): void {
+        $instance = new class {
+            use HasAttributes;
+            use HasLabel;
+        };
+
+        $instance = $instance->attributes($attributes)->label($label);
+
+        self::assertSame(
+            $expectedValue,
+            $instance->getAttribute(Attribute::LABEL, ''),
+            $message,
+        );
+        self::assertSame(
+            $expectedRenderAttributes,
+            Attributes::render($instance->getAttributes()),
+            $message,
+        );
+    }
+}

--- a/tests/Provider/LabelProvider.php
+++ b/tests/Provider/LabelProvider.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Provider;
+
+use PHPForge\Support\Stub\{BackedString, Unit};
+use Stringable;
+use UnitEnum;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\HasLabelTest} test cases.
+ *
+ * Provides representative input/output pairs for the `label` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class LabelProvider
+{
+    /**
+     * @phpstan-return array<
+     *   string,
+     *   array{string|Stringable|UnitEnum|null, mixed[], string|Stringable|UnitEnum|null, string, string},
+     * >
+     */
+    public static function values(): array
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'group-label';
+            }
+        };
+
+        return [
+            'enum backed string' => [
+                BackedString::VALUE,
+                [],
+                BackedString::VALUE,
+                ' label="value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'enum unit' => [
+                Unit::value,
+                [],
+                Unit::value,
+                ' label="value"',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                null,
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                'New Label',
+                ['label' => 'Old Label'],
+                'New Label',
+                ' label="New Label"',
+                "Should return new 'label' after replacing the existing 'label' attribute.",
+            ],
+            'string' => [
+                'Group Label',
+                [],
+                'Group Label',
+                ' label="Group Label"',
+                'Should return the attribute value after setting it.',
+            ],
+            'stringable' => [
+                $stringable,
+                [],
+                $stringable,
+                ' label="group-label"',
+                'Should return the attribute value after setting it with a Stringable instance.',
+            ],
+            'unset with null' => [
+                null,
+                ['label' => 'Group Label'],
+                null,
+                '',
+                "Should unset the 'label' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}

--- a/tests/Provider/SelectedProvider.php
+++ b/tests/Provider/SelectedProvider.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Attribute\Tests\Provider;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Attribute\Tests\CanBeSelectedTest} test cases.
+ *
+ * Provides representative input/output pairs for the `selected` attribute.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class SelectedProvider
+{
+    /**
+     * @phpstan-return array<string, array{bool|null, mixed[], bool|null, string, string}>
+     */
+    public static function values(): array
+    {
+        return [
+            'boolean false' => [
+                false,
+                [],
+                false,
+                '',
+                'Should return the attribute value after setting it.',
+            ],
+            'boolean true' => [
+                true,
+                [],
+                true,
+                ' selected',
+                'Should return the attribute value after setting it.',
+            ],
+            'null' => [
+                null,
+                [],
+                null,
+                '',
+                "Should return an empty string when the attribute is set to 'null'.",
+            ],
+            'replace existing' => [
+                true,
+                ['selected' => false],
+                true,
+                ' selected',
+                "Should return new 'selected' after replacing the existing 'selected' attribute.",
+            ],
+            'unset with null' => [
+                null,
+                ['selected' => true],
+                null,
+                '',
+                "Should unset the 'selected' attribute when 'null' is provided after a value.",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
